### PR TITLE
Narrow variables assignments when testing for `invalid`

### DIFF
--- a/src/plugins/trackCodeFlow.spec.ts
+++ b/src/plugins/trackCodeFlow.spec.ts
@@ -57,7 +57,8 @@ describe('lintCodeFlow', () => {
             `16:2003:Not all the code paths assign 'b'`,
             `25:2003:Not all the code paths assign 'b'`,
             `42:2003:Not all the code paths assign 'b'`,
-            `51:2003:Not all the code paths assign 'b'`
+            `51:2003:Not all the code paths assign 'b'`,
+            `62:2003:Not all the code paths assign 'b'`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -93,7 +94,7 @@ describe('lintCodeFlow', () => {
         expect(actual).deep.equal(expected);
     });
 
-    it.only('implements unreachable-code', async () => {
+    it('implements unreachable-code', async () => {
         const diagnostics = await linter.run({
             ...project1,
             files: ['source/unreachable-code.brs'],

--- a/test/project1/source/assign-all-paths.brs
+++ b/test/project1/source/assign-all-paths.brs
@@ -51,6 +51,17 @@ sub error5()
     print "b"; b 'error
 end sub
 
+sub error6()
+    a = Rnd(10)
+    if a > 5
+        b = a
+    end if
+    if b <> invalid  ' opposite of narrowed exit
+        return
+    end if
+    print "b"; b ' error
+end sub
+
 sub ok1()
     a = Rnd(10)
     if a > 0
@@ -141,6 +152,61 @@ sub ok7()
         if a < -3
             b = 3
         end if
+    end if
+    print "b"; b
+end sub
+
+sub ok8()
+    a = Rnd(10)
+    if a > 5
+        b = a
+    end if
+    if b <> invalid ' narrowed
+        print "b"; b
+    end if
+end sub
+
+sub ok9()
+    a = Rnd(10)
+    if a > 5
+        b = a
+    end if
+    if (b = invalid) ' narrowed
+        print "b"; b
+    end if
+end sub
+
+sub ok10()
+    a = Rnd(10)
+    if a > 5
+        b = a
+    end if
+    if b = invalid ' narrowed exit
+        return
+    end if
+    print "b"; b
+end sub
+
+sub ok11()
+    a = Rnd(10)
+    if a > 5
+        b = a
+    end if
+    if b = invalid ' narrowed exit
+        return
+    end if
+    print "b"; b
+end sub
+
+sub ok12()
+    a = Rnd(10)
+    if a > 5
+        b = a
+    end if
+    if b <> invalid
+        print "b"; b
+    else ' narrowed exit
+        return
     end if
     print "b"; b
 end sub


### PR DESCRIPTION
Fixes #9 

```brightscript
sub ok8()
    a = Rnd(10)
    if a > 5
        b = a
    end if
    if b <> invalid ' narrow variable as safe
        print "b"; b
    end if
end sub

sub ok9()
    a = Rnd(10)
    if a > 5
        b = a
    end if
    if b = invalid ' narrowed
        print "b"; b
    end if
end sub

sub ok10()
    a = Rnd(10)
    if a > 5
        b = a
    end if
    if b = invalid ' narrowed exit
        return
    end if
    print "b"; b
end sub
```