### PR TITLE
Add missing changelog info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+
+
+## [0.6.0](https://github.com/rokucommunity/bslint/compare/v0.5.0...v0.6.0) - 2021-10-27
 ### Added
- - cli to run linter without needing to configure brighterscript
- - baseline lint rules
+ - associative array comma linting and fixing ([#40](https://github.com/rokucommunity/bslint/pull/40))
+ - automatic code fix for removing `as void` when changing a function to sub ([#42](https://github.com/rokucommunity/bslint/pull/40))
 
 
-[0.1.0]:    https://github.com/rokucommunity/bslint/compare/31ac6b46fe6f4e5b9b2e23f60c675327ab2bb207...v0.1.0
+
+## [0.5.0](https://github.com/rokucommunity/bslint/compare/v0.4.0...v0.5.0) - 2021-07-07
+### Added
+ - check scripts/components usage (behind `--checkUsage` flag). ([#35](https://github.com/rokucommunity/bslint/pull/35))
+
+
+## [0.4.0](https://github.com/rokucommunity/bslint/compare/v0.3.0...v0.4.0) - 2021-05-25
+### Added
+ - automatic code fixes ([#28](https://github.com/rokucommunity/bslint/pull/28))
+    - function/sub style
+    - `then` style
+    - if condition grouping with/without parenthesis
+
+
+
+## [0.3.0](https://github.com/rokucommunity/bslint/compare/v0.2.0...v0.3.0) - 2021-05-19
+### Added
+ - Add ignores and globals ([#27](https://github.com/rokucommunity/bslint/pull/27))
+### Fixed
+ - invoking classes fix ([#26](https://github.com/rokucommunity/bslint/pull/26))
+
+
+
+## [0.2.0](https://github.com/rokucommunity/bslint/compare/v0.1.0...v0.2.0) - 2021-05-13
+### Added
+ - no-print-rule ([#19](https://github.com/rokucommunity/bslint/pull/19))
+ - Add namespaces and super ([#24](https://github.com/rokucommunity/bslint/pull/24))
+
+
+
+## [0.1.0](https://github.com/rokucommunity/bslint/compare/213c530d29ff49771da2860cf4cae79c5341e8cb...v0.1.0) - 2021-02-22
+### Added
+Initial release


### PR DESCRIPTION
Bring the changelog up to date. This also includes the changelog for a planned release for today (v0.6.0)