### PR TITLE
Fixed test after brighterscript bump

### DIFF
--- a/src/plugins/codeStyle/index.spec.ts
+++ b/src/plugins/codeStyle/index.spec.ts
@@ -486,7 +486,7 @@ describe('codeStyle', () => {
         it('off with eol', async() => {
             const diagnostics = await linter.run({
                 ...project1,
-                files: ['source/main.brs'],
+                files: ['source/eol-last.brs'],
                 rules: {
                     'eol-last': 'off'
                 }


### PR DESCRIPTION
I was using `main.brs` which I didn't notice had other uses. I created my own file for the `eol-last` test that was failing.