### PR TITLE
Prevent "unused var" in goto loop

### DIFF
--- a/src/plugins/trackCodeFlow/index.spec.ts
+++ b/src/plugins/trackCodeFlow/index.spec.ts
@@ -267,7 +267,9 @@ describe('trackCodeFlow', () => {
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
             `02:LINT1005:Variable 'a' is set but value is never used`,
-            `08:LINT1005:Variable 'a' is set but value is never used`
+            `08:LINT1005:Variable 'a' is set but value is never used`,
+            `12:LINT1005:Variable 'a' is set but value is never used`,
+            `21:LINT1005:Variable 'd' is set but value is never used`
         ];
         expect(actual).deep.equal(expected);
     });

--- a/test/project1/source/unused-variable.brs
+++ b/test/project1/source/unused-variable.brs
@@ -8,6 +8,19 @@ sub error2()
     a = 20 ' error
 end sub
 
+sub error3()
+    a = 10 ' error
+    loop:
+    b = 0
+    c = 10 ' should be an error but...
+    d = 10
+    if b < 10
+        b = b + 1
+        goto loop
+    end if
+    d = 30 ' error
+end sub
+
 sub ok1(usageNotChecked)
     a = 10
     print a


### PR DESCRIPTION
Prevent false positives of unused variables within `goto` loops by considering any var, between 1st found label and a `goto` statement) as being "used".
Inaccurate but better than nothing?