### PR TITLE
Fixes issue with tagging namespaced function as Unitialized Vars

### DIFF
--- a/src/plugins/trackCodeFlow/index.spec.ts
+++ b/src/plugins/trackCodeFlow/index.spec.ts
@@ -94,6 +94,50 @@ describe('trackCodeFlow', () => {
         });
     });
 
+    describe('namespaced functions', () => {
+        it('does not mark as uninitialised vars when used within namespace', async () => {
+            const diagnostics = await linter.run({
+                ...project1,
+                files: ['source/namespace-functions.bs'],
+                rules: {
+                    'unused-variable': 'error'
+                }
+            });
+            const actual = fmtDiagnostics(diagnostics);
+            const expected = [];
+            expect(actual).deep.equal(expected);
+        });
+
+        it('does not mark as uninitialised vars when used in a class within namespace', async () => {
+            const diagnostics = await linter.run({
+                ...project1,
+                files: ['source/namespace-functions-in-class.bs'],
+                rules: {
+                    'unused-variable': 'error'
+                }
+            });
+            const actual = fmtDiagnostics(diagnostics);
+            const expected = [];
+            expect(actual).deep.equal(expected);
+        });
+
+        it('does mark as uninitialised vars when used outside of namespace', async () => {
+            const diagnostics = await linter.run({
+                ...project1,
+                files: ['source/namespace-functions-outside-namespace.bs'],
+                rules: {
+                    'unused-variable': 'error'
+                }
+            });
+            const actual = fmtDiagnostics(diagnostics);
+            const expected = [
+                `11:1001:Cannot find name 'one'`,
+                `11:LINT1001:Using uninitialised variable 'one' when this file is included in scope 'source'`
+            ];
+            expect(actual).deep.equal(expected);
+        });
+    });
+
     it('implements assign-all-paths', async () => {
         const diagnostics = await linter.run({
             ...project1,

--- a/src/plugins/trackCodeFlow/varTracking.ts
+++ b/src/plugins/trackCodeFlow/varTracking.ts
@@ -421,6 +421,7 @@ function deferredVarLinter(
         const key = name?.toLowerCase();
         let hasCallable = key ? callables.has(key) || toplevel.has(key) : false;
         if (key && !hasCallable && namespace) {
+            // check if this could be a callable in the current namespace
             const keyUnderNamespace = `${namespace.getName(ParseMode.BrightScript)}_${key}`.toLowerCase();
             hasCallable = callables.has(keyUnderNamespace);
         }

--- a/test/project1/source/namespace-functions-in-class.bs
+++ b/test/project1/source/namespace-functions-in-class.bs
@@ -1,0 +1,16 @@
+
+namespace TestNamespace
+
+    function one() as integer
+        return 1
+    end function
+
+
+    class TestClass
+        value as integer
+        sub new()
+            m.value = one()
+        end sub
+    end class
+
+end namespace

--- a/test/project1/source/namespace-functions-outside-namespace.bs
+++ b/test/project1/source/namespace-functions-outside-namespace.bs
@@ -1,0 +1,12 @@
+
+namespace TestNamespace
+
+    function one() as integer
+        return 1
+    end function
+
+end namespace
+
+function two() as integer
+    return one() + 1
+end function

--- a/test/project1/source/namespace-functions.bs
+++ b/test/project1/source/namespace-functions.bs
@@ -1,0 +1,12 @@
+
+namespace TestNamespace
+
+    function one() as integer
+        return 1
+    end function
+
+    function two() as integer
+        return one() + one()
+    end function
+
+end namespace


### PR DESCRIPTION
This was an issue when a function was used within the namespace it was declared in.

eg:

```bs
namespace SomeNamespace

  sub alpha() 
  end sub
  
  sub beta()
     alpha() ' This was previously giving LINT1001 error (Using uninitialised variable)
  end sub

end namespace
```