### PR TITLE
Don't mark vars with leading underscores as unused

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/chai": "^4.3.0",
+        "@types/fs-extra": "^9.0.13",
         "@types/minimatch": "^3.0.4",
         "@types/mocha": "^9.1.0",
         "@types/mock-fs": "^4.10.0",
@@ -483,6 +484,15 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.5",
@@ -5163,6 +5173,15 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/json-schema": {
       "version": "7.0.5",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",
+    "@types/fs-extra": "^9.0.13",
     "@types/minimatch": "^3.0.4",
     "@types/mocha": "^9.1.0",
     "@types/mock-fs": "^4.10.0",

--- a/src/plugins/trackCodeFlow/varTracking.ts
+++ b/src/plugins/trackCodeFlow/varTracking.ts
@@ -353,7 +353,7 @@ export function createVarLinter(
 
     function finalize(locals: Map<string, VarInfo>) {
         locals.forEach(local => {
-            if (!local.isUsed && !local.restriction) {
+            if (!local.isUsed && !local.restriction && !local.name.startsWith('_')) {
                 diagnostics.push({
                     severity: severity.unusedVariable,
                     code: VarLintError.UnusedVariable,

--- a/src/util.ts
+++ b/src/util.ts
@@ -38,8 +38,8 @@ export function normalizeConfig(options: BsLintConfig) {
     const baseConfig = {
         rules: getDefaultRules()
     };
-    const projectConfig = mergeConfigs(loadConfig(options), { rules: options.rules });
-    return mergeConfigs(baseConfig, projectConfig);
+    const projectConfig = mergeConfigs(loadConfig(options), { rules: options.rules } as any);
+    return mergeConfigs(baseConfig as any, projectConfig);
 }
 
 export function mergeConfigs(a: BsLintConfig, b: BsLintConfig): BsLintConfig {


### PR DESCRIPTION
Roku recently introduced the paradigm of using underscores to indicate that a variable is unused. bslint should probably follow the same concept. 

Question: Should we revise the ` 'unused-variable'?: RuleSeverity;` to contain options instead of just severity? Perhaps something like:

```
{
    "unused-variable": "all" | "all-except-leading-underscores" | etc..
}```