### PR TITLE
Fix code flow bug with try/catch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { BsConfig, Program, DiagnosticSeverity } from 'brighterscript';
+import { BsConfig, Program, DiagnosticSeverity, CompilerPlugin } from 'brighterscript';
 import Linter from './Linter';
 import CheckUsage from './plugins/checkUsage';
 import CodeStyle from './plugins/codeStyle';
@@ -71,9 +71,10 @@ export interface BsLintRules {
 
 export { Linter };
 
-export default function factory() {
+export default function factory(): CompilerPlugin {
     const contextMap = new WeakMap<Program, PluginWrapperContext>();
     return {
+        name: 'bslint',
         afterProgramCreate: (program: Program) => {
             const context = createContext(program);
             contextMap.set(program, context);

--- a/src/plugins/trackCodeFlow/index.spec.ts
+++ b/src/plugins/trackCodeFlow/index.spec.ts
@@ -45,10 +45,12 @@ describe('trackCodeFlow', () => {
         program.setFile('source/main.brs', `
             sub main()
                 try
-                    text2 = "true"
+                    text1 = "a"
+                    text2 = "b"
                 catch e
-                    text2 = "false"
+                    text1 = "c"
                 end try
+                print text1
                 print text2
             end sub
         `);
@@ -56,7 +58,9 @@ describe('trackCodeFlow', () => {
 
         expect(
             fmtDiagnostics(program.getDiagnostics())
-        ).to.eql([]);
+        ).to.eql([
+            `10:LINT1003:Not all the code paths assign 'text2'`
+        ]);
     });
 
     it('detects use of uninitialized vars', async () => {

--- a/src/plugins/trackCodeFlow/varTracking.ts
+++ b/src/plugins/trackCodeFlow/varTracking.ts
@@ -1,4 +1,4 @@
-import { BscFile, FunctionExpression, BsDiagnostic, Range, isForStatement, isForEachStatement, isIfStatement, isAssignmentStatement, isNamespaceStatement, NamespaceStatement, Expression, isVariableExpression, isBinaryExpression, TokenKind, Scope, CallableContainerMap, DiagnosticSeverity, isLiteralInvalid, isWhileStatement, isClassMethodStatement, isBrsFile, isCatchStatement, isLabelStatement, isGotoStatement, NamespacedVariableNameExpression, ParseMode } from 'brighterscript';
+import { BscFile, FunctionExpression, BsDiagnostic, Range, isForStatement, isForEachStatement, isIfStatement, isAssignmentStatement, isNamespaceStatement, NamespaceStatement, Expression, isVariableExpression, isBinaryExpression, TokenKind, Scope, CallableContainerMap, DiagnosticSeverity, isLiteralInvalid, isWhileStatement, isClassMethodStatement, isBrsFile, isCatchStatement, isLabelStatement, isGotoStatement, NamespacedVariableNameExpression, ParseMode, isTryCatchStatement } from 'brighterscript';
 import { LintState, StatementInfo, NarrowingInfo, VarInfo, VarRestriction } from '.';
 import { PluginContext } from '../../util';
 
@@ -246,7 +246,7 @@ export function createVarLinter(
         if (!parent.locals) {
             parent.locals = locals;
         } else {
-            const isParentIf = isIfStatement(parent.stat);
+            const isParentBranched = isIfStatement(parent.stat) || isTryCatchStatement(parent.stat);
             const isLoop = isForStatement(closed.stat) || isForEachStatement(closed.stat) || isWhileStatement(closed.stat);
             locals.forEach((local, name) => {
                 const parentLocal = parent.locals.get(name);
@@ -254,8 +254,8 @@ export function createVarLinter(
                 if (local.restriction) {
                     local.isUnsafe = true;
                 }
-                // if a parent var isn't partial then the var stays non-partial
-                if (isParentIf) {
+                // combine attributes / met branches
+                if (isParentBranched) {
                     if (parentLocal) {
                         local.isUnsafe = parentLocal.isUnsafe || local.isUnsafe;
                         local.metBranches = (parentLocal.metBranches ?? 0) + 1;


### PR DESCRIPTION
Work-in-progress:

Fixes a bug in trackCodeFlow where variables assigned in try/catch falsely trigger the "not all code paths assign..." error.

![image](https://github.com/rokucommunity/bslint/assets/2544493/f48da673-8af9-4e7d-a39d-02d90e2799c1)
