### PR TITLE
Adding default config logic - to support defining broadcast safe color definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .nyc_output
 coverage
 *.code-workspace
+/src/config/config.local.ts

--- a/src/config/config.default.ts
+++ b/src/config/config.default.ts
@@ -1,0 +1,12 @@
+import { Config } from './configTypes';
+
+const defaultConfig: Config = {
+    colors: {
+        broadcastSafe: {
+            black: '161616',
+            white: 'EBEBEB'
+        }
+    }
+};
+
+export default defaultConfig;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,25 @@
+import defaultConfig from './config.default';
+import { Config } from './configTypes';
+
+let localConfig: Config;
+
+async function loadConfig() {
+    let config;
+    try {
+        const module = await import('./config.local');
+        config = module.default;
+    } catch (error) {
+        config = {};
+    }
+    return config;
+}
+
+loadConfig().then(config => {
+    localConfig = config;
+}).catch(() => {
+    console.error('Local configuration file is not defined, using default config');
+    localConfig = {} as Config;
+});
+
+const config: Config = { ...defaultConfig, ...localConfig };
+export default config;

--- a/src/config/configTypes.ts
+++ b/src/config/configTypes.ts
@@ -1,0 +1,12 @@
+export interface BroadcastSafeColors {
+    black: string;
+    white: string;
+}
+
+export interface ColorsConfig {
+    broadcastSafe: BroadcastSafeColors;
+}
+
+export interface Config {
+    colors: ColorsConfig;
+}

--- a/src/createColorValidator.ts
+++ b/src/createColorValidator.ts
@@ -1,5 +1,6 @@
 import { BsDiagnostic, Range } from 'brighterscript';
 import { messages } from './plugins/codeStyle/diagnosticMessages';
+import config from './config/config';
 import { BsLintRules, RuleColorFormat, RuleColorCase, RuleColorAlpha, RuleColorAlphaDefaults, RuleColorCertCompliant } from './index';
 
 export function createColorValidator(severity: Readonly<BsLintRules>) {
@@ -81,10 +82,8 @@ function validateColorCase(matches: RegExpMatchArray, range: Range, diagnostics:
 function validateColorCertCompliance(matches: RegExpMatchArray, range: Range, diagnostics: (Omit<BsDiagnostic, 'file'>)[], colorFormat: RuleColorFormat, certCompliant: RuleColorCertCompliant) {
     const validateCertCompliant = certCompliant === 'always';
     if (validateCertCompliant && matches) {
-        const BROADCAST_SAFE_BLACK = '161616';
-        const BROADCAST_SAFE_WHITE = 'EBEBEB';
-        const MAX_BLACK_LUMA = getColorLuma(BROADCAST_SAFE_BLACK);
-        const MAX_WHITE_LUMA = getColorLuma(BROADCAST_SAFE_WHITE);
+        const MAX_BLACK_LUMA = getColorLuma(config.colors.broadcastSafe.black);
+        const MAX_WHITE_LUMA = getColorLuma(config.colors.broadcastSafe.white);
         let colorValue = matches[0];
         const charsToStrip = (colorFormat === 'hash-hex') ? 1 : 2;
         colorValue = colorValue.substring(charsToStrip);


### PR DESCRIPTION
First pass. Wondering if we need unittests for the Config logic...

Todo
Update Readme