### PR TITLE
Sorts diagnostics in tests for errors on same line

### DIFF
--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -123,7 +123,8 @@ export function fmtDiagnostics(diagnostics: BsDiagnostic[]) {
     return diagnostics
         .filter((d) => d.severity && d.severity < 4)
         .sort((a, b) => a.range.start.line - b.range.start.line)
-        .map((d) => `${pad(d.range.start.line + 1)}:${d.code}:${d.message}`);
+        .map((d) => `${pad(d.range.start.line + 1)}:${d.code}:${d.message}`)
+        .sort();
 }
 
 /**


### PR DESCRIPTION
This fixes the tests when tested using Brighterscript v1 once the Brighterscript validator does single scope validation