### PR TITLE
Removing peer-dependency because it keeps causing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
     "ts-node": "^10.7.0",
     "typescript": "^4.9.4"
   },
-  "peerDependencies": {
-    "brighterscript": "1.0.0-alpha.34"
-  },
   "mocha": {
     "spec": "src/**/*.spec.ts",
     "require": [


### PR DESCRIPTION
Removing the peerDependency section in the package.json because I keep forgetting to update it when I cut releases, which causes issues. We've already established that you need to keep the alpha version of bslint in sync with brighterscript, that should be enough. 