### PR TITLE
Fix validation crash when leadingTrivia is undefined

### DIFF
--- a/src/plugins/codeStyle/index.spec.ts
+++ b/src/plugins/codeStyle/index.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { expect } from 'chai';
-import { AALiteralExpression, AfterProgramCreateEvent, AssignmentStatement, ParseMode, Parser, Program, util } from 'brighterscript';
+import { AALiteralExpression, AfterProgramCreateEvent, AssignmentStatement, BrsFile, FunctionStatement, ParseMode, Parser, Program, util } from 'brighterscript';
 import Linter from '../../Linter';
 import CodeStyle, { collectWrappingAAMembersIndexes } from './index';
 import bslintFactory, { BsLintConfig } from '../../index';
@@ -414,6 +414,22 @@ describe('codeStyle', () => {
         expect(actual).deep.equal(expected);
     });
 
+    it('does not crash when node has no leadingTrivia', () => {
+        (program.options as any).rules['consistent-return'] = 'error';
+        const file = program.setFile<BrsFile>('source/main.bs', `
+            'comment
+            sub test()
+            end sub
+
+            'TODO
+            sub test2()
+            end sub
+        `);
+        (file.ast.statements[0] as FunctionStatement).func.tokens.functionType.leadingTrivia = undefined;
+        program.validate();
+        const codeStyle = new CodeStyle(createContext(program));
+        codeStyle.validateBrsFile(file);
+    });
 
     describe('enforce no todo', () => {
         it('default todo pattern', async () => {

--- a/src/plugins/codeStyle/index.ts
+++ b/src/plugins/codeStyle/index.ts
@@ -214,7 +214,7 @@ export default class CodeStyle implements CompilerPlugin {
                 }
             },
             AstNode: (node: Statement | Expression) => {
-                const comments = [...node.leadingTrivia, ...node.endTrivia].filter(t => t.kind === TokenKind.Comment);
+                const comments = [...node.leadingTrivia ?? [], ...node.endTrivia ?? []].filter(t => t.kind === TokenKind.Comment);
                 if (validateTodo && comments.length > 0) {
                     for (const e of comments) {
                         if (this.lintContext.todoPattern.test(e.text)) {


### PR DESCRIPTION
Fixes a crash when validating a file where a comment has an undefined leadingTrivia array.