### PR TITLE
Actually add name property to plugin classes

### DIFF
--- a/src/plugins/codeStyle/index.ts
+++ b/src/plugins/codeStyle/index.ts
@@ -40,7 +40,7 @@ import { Location } from 'vscode-languageserver-types';
 
 export default class CodeStyle implements CompilerPlugin {
 
-    name: 'codeStyle';
+    name = 'bslint-codeStyle';
 
     constructor(private lintContext: PluginContext) {
     }

--- a/src/plugins/trackCodeFlow/index.ts
+++ b/src/plugins/trackCodeFlow/index.ts
@@ -55,7 +55,7 @@ export interface LintState {
 
 export default class TrackCodeFlow implements CompilerPlugin {
 
-    name: 'trackCodeFlow';
+    name = 'bslint-trackCodeFlow';
 
     constructor(private lintContext: PluginContext) {
     }


### PR DESCRIPTION
The "sub plugins" in BsLint don't actually have names .. this changes it so they are named. The only difference is that they show up in the logs better.

Before:

![image](https://github.com/user-attachments/assets/20e73d50-9152-4700-a323-f613ceb326b6)


After:

![image](https://github.com/user-attachments/assets/93811d46-e2c6-45d4-ad54-4d401530c2c9)
![image](https://github.com/user-attachments/assets/4806586a-2b76-4725-a7c5-0bd957d17394)