### PR TITLE
Identify unused function parameters

### DIFF
--- a/src/plugins/trackCodeFlow/index.spec.ts
+++ b/src/plugins/trackCodeFlow/index.spec.ts
@@ -356,7 +356,8 @@ describe('trackCodeFlow', () => {
             `02:LINT1005:Variable 'a' is set but value is never used`,
             `08:LINT1005:Variable 'a' is set but value is never used`,
             `12:LINT1005:Variable 'a' is set but value is never used`,
-            `21:LINT1005:Variable 'd' is set but value is never used`
+            `21:LINT1005:Variable 'd' is set but value is never used`,
+            "24:LINT1005:Variable 'unusedArg' is set but value is never used",
         ];
         expect(actual).deep.equal(expected);
     });

--- a/src/plugins/trackCodeFlow/varTracking.ts
+++ b/src/plugins/trackCodeFlow/varTracking.ts
@@ -352,13 +352,19 @@ export function createVarLinter(
     }
 
     function finalize(locals: Map<string, VarInfo>) {
-        locals.forEach(local => {
-            if (!local.isUsed && !local.restriction) {
+        // check for unused variables (both locals and function parameters)
+        const allVariables = [...locals.values(), ...args.values()];
+
+        allVariables.forEach(variable => {
+            const isUnusedLocal = !variable.isParam && !variable.isUsed && !variable.restriction;
+            const isUnusedParam = variable.isParam && !variable.isUsed && variable.name !== 'm' && variable.name !== 'super';
+
+            if (isUnusedLocal || isUnusedParam) {
                 diagnostics.push({
                     severity: severity.unusedVariable,
                     code: VarLintError.UnusedVariable,
-                    message: `Variable '${local.name}' is set but value is never used`,
-                    range: local.range,
+                    message: `Variable '${variable.name}' is set but value is never used`,
+                    range: variable.range,
                     file: file
                 });
             }

--- a/test/project1/source/unused-variable.brs
+++ b/test/project1/source/unused-variable.brs
@@ -21,7 +21,12 @@ sub error3()
     d = 30 ' error
 end sub
 
-sub ok1(usageNotChecked)
+sub error4(unusedArg) ' error
+    a = 10
+    print a
+end sub
+
+sub ok1()
     a = 10
     print a
     b = 20


### PR DESCRIPTION
This enables bslint to flag unused function parameters. The roku compiler already flags these, so it would be helpful if bslint could catch them as well.

I considered adding a separate rule, but I didn't think it was worth the added complexity. Popular linters like ESLint flag unused local variables and function parameters as a single rule (https://eslint.org/docs/latest/rules/no-unused-vars), so I figured that bslint could follow suit.

Fixes #72