### PR TITLE
Add for-terminator-style rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export type RuleColorCase = 'upper' | 'lower' | 'off';
 export type RuleColorAlpha = 'always' | 'allowed' | 'never' | 'off';
 export type RuleColorAlphaDefaults = 'allowed' | 'only-hidden' | 'never' | 'off';
 export type RuleColorCertCompliant = 'always' | 'off'; // Roku cert requirement for broadcast safe colors. 6.4
+export type RuleForTerminator = 'end-for' | 'next' | 'off';
 
 export type BsLintConfig = Pick<BsConfig, 'project' | 'rootDir' | 'files' | 'cwd' | 'watch'> & {
     lintConfig?: string;
@@ -53,6 +54,7 @@ export type BsLintConfig = Pick<BsConfig, 'project' | 'rootDir' | 'files' | 'cwd
         'no-assocarray-component-field-type'?: RuleSeverity;
         'no-array-component-field-type'?: RuleSeverity;
         'no-regex-duplicates'?: RuleSeverity;
+        'for-terminator-style'?: RuleForTerminator;
     };
     globals?: string[];
     ignores?: string[];
@@ -90,6 +92,7 @@ export interface BsLintRules {
     noAssocarrayComponentFieldType: BsLintSeverity;
     noArrayComponentFieldType: BsLintSeverity;
     noRegexDuplicates: BsLintSeverity;
+    forTerminatorStyle: RuleForTerminator;
 }
 
 export { Linter };

--- a/src/plugins/codeStyle/diagnosticMessages.ts
+++ b/src/plugins/codeStyle/diagnosticMessages.ts
@@ -26,7 +26,9 @@ export enum CodeStyleError {
     ColorCertCompliant = 'LINT3023',
     NoAssocarrayFieldType = 'LINT3024',
     NoArrayFieldType = 'LINT3025',
-    NoRegexDuplicates = 'LINT3026'
+    NoRegexDuplicates = 'LINT3026',
+    ForTerminatorEndForExpected = 'LINT3027',
+    ForTerminatorNextExpected = 'LINT3028'
 }
 
 const CS = 'Code style:';
@@ -229,6 +231,20 @@ export const messages = {
         code: CodeStyleError.NoRegexDuplicates,
         severity: severity,
         source: 'bslint',
+        range
+    }),
+    expectedEndForTerminator: (range: Range) => ({
+        severity: DiagnosticSeverity.Error,
+        code: CodeStyleError.ForTerminatorEndForExpected,
+        source: 'bslint',
+        message: `${CS} expected 'end for' terminator`,
+        range
+    }),
+    expectedNextTerminator: (range: Range) => ({
+        severity: DiagnosticSeverity.Error,
+        code: CodeStyleError.ForTerminatorNextExpected,
+        source: 'bslint',
+        message: `${CS} expected 'next' terminator`,
         range
     })
 };

--- a/src/plugins/codeStyle/index.spec.ts
+++ b/src/plugins/codeStyle/index.spec.ts
@@ -7,6 +7,8 @@ import bslintFactory, { BsLintConfig } from '../../index';
 import { createContext, PluginWrapperContext } from '../../util';
 import { expectDiagnostics, expectDiagnosticsFmt, fmtDiagnostics } from '../../testHelpers.spec';
 import { messages } from './diagnosticMessages';
+import { getFixes } from './styleFixes';
+import { applyEdits } from '../../textEdit';
 
 describe('codeStyle', () => {
     let linter: Linter;
@@ -49,6 +51,7 @@ describe('codeStyle', () => {
                 'color-alpha-defaults': 'off',
                 'color-cert': 'off',
                 'no-regex-duplicates': 'off',
+                'for-terminator-style': 'off',
                 ...(rules ?? {})
             }
         } as BsLintConfig);
@@ -255,6 +258,222 @@ describe('codeStyle', () => {
                 `14:LINT3007:Code style: remove parenthesis around condition`
             ];
             expect(actual).deep.equal(expected);
+        });
+    });
+
+    describe('validate for terminator style', () => {
+        const mixedSource = `
+            sub test()
+                for i = 0 to 5
+                    print i
+                end for
+
+                for i = 0 to 5
+                    print i
+                next
+
+                for each x in [1, 2, 3]
+                    print x
+                end for
+
+                for each x in [1, 2, 3]
+                    print x
+                next
+
+                while true
+                    print "loop"
+                end while
+
+                for i = 0 to 2
+                    for j = 0 to 2
+                        print j
+                    next
+                end for
+            end sub
+        `;
+
+        it('does nothing when set to off', () => {
+            init({ 'for-terminator-style': 'off' });
+            program.setFile('source/main.brs', mixedSource);
+            program.validate();
+            expectDiagnosticsFmt(program, []);
+        });
+
+        it(`flags 'next' under end-for mode (default)`, () => {
+            init({ 'for-terminator-style': 'end-for' });
+            program.setFile('source/main.brs', mixedSource);
+            program.validate();
+            expectDiagnosticsFmt(program, [
+                `09:LINT3027:Code style: expected 'end for' terminator`,
+                `17:LINT3027:Code style: expected 'end for' terminator`,
+                `26:LINT3027:Code style: expected 'end for' terminator`
+            ]);
+        });
+
+        it(`flags 'end for' under next mode`, () => {
+            init({ 'for-terminator-style': 'next' });
+            program.setFile('source/main.brs', mixedSource);
+            program.validate();
+            expectDiagnosticsFmt(program, [
+                `05:LINT3028:Code style: expected 'next' terminator`,
+                `13:LINT3028:Code style: expected 'next' terminator`,
+                `27:LINT3028:Code style: expected 'next' terminator`
+            ]);
+        });
+
+        it('never flags while loops regardless of mode', () => {
+            for (const mode of ['end-for', 'next', 'off'] as const) {
+                init({ 'for-terminator-style': mode });
+                program.setFile('source/main.brs', `
+                    sub test()
+                        while true
+                            print "loop"
+                        end while
+                    end sub
+                `);
+                program.validate();
+                expectDiagnosticsFmt(program, []);
+            }
+        });
+
+        it('flags nested loops independently', () => {
+            // outer `end for` and inner `next` under end-for mode → only inner is flagged
+            init({ 'for-terminator-style': 'end-for' });
+            program.setFile('source/main.brs', `
+                sub test()
+                    for i = 0 to 2
+                        for j = 0 to 2
+                            print j
+                        next
+                    end for
+                end sub
+            `);
+            program.validate();
+            expectDiagnosticsFmt(program, [
+                `06:LINT3027:Code style: expected 'end for' terminator`
+            ]);
+        });
+
+        function applyAllFixes(src: string, code: string): string {
+            const diagnostics = program.getDiagnostics().filter(d => d.code === code);
+            const allChanges = diagnostics.flatMap(d => getFixes(d as any).changes);
+            return applyEdits(src, allChanges);
+        }
+
+        it(`fix replaces 'next' with 'end for' under end-for mode`, () => {
+            init({ 'for-terminator-style': 'end-for' });
+            program.setFile('source/main.brs', mixedSource);
+            program.validate();
+
+            const fixed = applyAllFixes(mixedSource, 'LINT3027');
+            const expected = `
+            sub test()
+                for i = 0 to 5
+                    print i
+                end for
+
+                for i = 0 to 5
+                    print i
+                end for
+
+                for each x in [1, 2, 3]
+                    print x
+                end for
+
+                for each x in [1, 2, 3]
+                    print x
+                end for
+
+                while true
+                    print "loop"
+                end while
+
+                for i = 0 to 2
+                    for j = 0 to 2
+                        print j
+                    end for
+                end for
+            end sub
+        `;
+            expect(fixed).to.equal(expected);
+        });
+
+        it(`fix replaces 'end for' with 'next' under next mode`, () => {
+            init({ 'for-terminator-style': 'next' });
+            program.setFile('source/main.brs', mixedSource);
+            program.validate();
+
+            const fixed = applyAllFixes(mixedSource, 'LINT3028');
+            const expected = `
+            sub test()
+                for i = 0 to 5
+                    print i
+                next
+
+                for i = 0 to 5
+                    print i
+                next
+
+                for each x in [1, 2, 3]
+                    print x
+                next
+
+                for each x in [1, 2, 3]
+                    print x
+                next
+
+                while true
+                    print "loop"
+                end while
+
+                for i = 0 to 2
+                    for j = 0 to 2
+                        print j
+                    next
+                next
+            end sub
+        `;
+            expect(fixed).to.equal(expected);
+        });
+
+        it('fix preserves indentation and trailing comment', () => {
+            init({ 'for-terminator-style': 'end-for' });
+            const src = `
+                sub test()
+                    for i = 0 to 2
+                        print i
+                    next ' done iterating
+                end sub
+            `;
+            program.setFile('source/main.brs', src);
+            program.validate();
+
+            const fixed = applyAllFixes(src, 'LINT3027');
+            // 'next' replaced in place; preceding indent and trailing comment stay
+            expect(fixed).to.contain(`                    end for ' done iterating\n`);
+        });
+
+        it(`fix on nested loops only touches the targeted terminator`, () => {
+            init({ 'for-terminator-style': 'end-for' });
+            const src = `
+                sub test()
+                    for i = 0 to 2
+                        for j = 0 to 2
+                            print j
+                        next
+                    end for
+                end sub
+            `;
+            program.setFile('source/main.brs', src);
+            program.validate();
+
+            const fixed = applyAllFixes(src, 'LINT3027');
+            // outer 'end for' was already correct; inner 'next' became 'end for'
+            const innerEndFor = fixed.indexOf('                        end for');
+            const outerEndFor = fixed.indexOf('                    end for');
+            expect(innerEndFor).to.be.greaterThan(0);
+            expect(outerEndFor).to.be.greaterThan(0);
+            expect(fixed).to.not.contain('next');
         });
     });
 

--- a/src/plugins/codeStyle/index.ts
+++ b/src/plugins/codeStyle/index.ts
@@ -25,7 +25,8 @@ import {
     isIfStatement,
     isFunctionExpression,
     AstNode,
-    Expression
+    Expression,
+    Range
 } from 'brighterscript';
 import { RuleAAComma } from '../..';
 import { addFixAllToEvent, addFixesToEvent } from '../../textEdit';
@@ -97,7 +98,7 @@ export default class CodeStyle {
     validateBrsFile(file: BrsFile) {
         const diagnostics: (Omit<BsDiagnostic, 'file'>)[] = [];
         const { severity } = this.lintContext;
-        const { inlineIfStyle, blockIfStyle, conditionStyle, noPrint, noTodo, noStop, aaCommaStyle, eolLast, colorFormat, noRegexDuplicates } = severity;
+        const { inlineIfStyle, blockIfStyle, conditionStyle, noPrint, noTodo, noStop, aaCommaStyle, eolLast, colorFormat, noRegexDuplicates, forTerminatorStyle } = severity;
         const validatePrint = noPrint !== DiagnosticSeverity.Hint;
         const validateTodo = noTodo !== DiagnosticSeverity.Hint;
         const validateNoStop = noStop !== DiagnosticSeverity.Hint;
@@ -111,6 +112,8 @@ export default class CodeStyle {
         const validateCondition = conditionStyle !== 'off';
         const requireConditionGroup = conditionStyle === 'group';
         const validateAAStyle = aaCommaStyle !== 'off';
+        const validateForTerminator = forTerminatorStyle !== 'off';
+        const requireForTerminatorNext = forTerminatorStyle === 'next';
         const walkExpressions = validateAAStyle || validateColorFormat;
         const validateEolLast = eolLast !== 'off';
         const disallowEolLast = eolLast === 'never';
@@ -231,6 +234,16 @@ export default class CodeStyle {
             StopStatement: s => {
                 if (validateNoStop) {
                     diagnostics.push(messages.noStop(s.tokens.stop.range, noStop));
+                }
+            },
+            ForStatement: s => {
+                if (validateForTerminator) {
+                    validateForTerminatorToken(s.endForToken, requireForTerminatorNext, diagnostics);
+                }
+            },
+            ForEachStatement: s => {
+                if (validateForTerminator) {
+                    validateForTerminatorToken(s.tokens.endFor, requireForTerminatorNext, diagnostics);
                 }
             }
         }), { walkMode: walkExpressions ? WalkMode.visitAllRecursive : WalkMode.visitStatementsRecursive });
@@ -421,6 +434,22 @@ export default class CodeStyle {
         }
 
         return argsStringValue;
+    }
+}
+
+function validateForTerminatorToken(
+    token: { kind: TokenKind; range: Range } | undefined,
+    requireNext: boolean,
+    diagnostics: (Omit<BsDiagnostic, 'file'>)[]
+) {
+    if (!token) {
+        return;
+    }
+    const isNext = token.kind === TokenKind.Next;
+    if (requireNext && !isNext) {
+        diagnostics.push(messages.expectedNextTerminator(token.range));
+    } else if (!requireNext && isNext) {
+        diagnostics.push(messages.expectedEndForTerminator(token.range));
     }
 }
 

--- a/src/plugins/codeStyle/styleFixes.ts
+++ b/src/plugins/codeStyle/styleFixes.ts
@@ -41,9 +41,22 @@ export function getFixes(diagnostic: BsDiagnostic): ChangeEntry {
             return addEolLast(diagnostic);
         case CodeStyleError.EolLastFound:
             return removeEolLast(diagnostic);
+        case CodeStyleError.ForTerminatorEndForExpected:
+            return replaceForTerminator(diagnostic, 'end for');
+        case CodeStyleError.ForTerminatorNextExpected:
+            return replaceForTerminator(diagnostic, 'next');
         default:
             return null;
     }
+}
+
+function replaceForTerminator(diagnostic: BsDiagnostic, text: string): ChangeEntry {
+    return {
+        diagnostic,
+        changes: [
+            replaceText(diagnostic.range, text)
+        ]
+    };
 }
 
 function addAAComma(diagnostic: BsDiagnostic) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,7 +30,8 @@ export function getDefaultRules(): BsLintConfig['rules'] {
         'no-print': 'off',
         'no-assocarray-component-field-type': 'off',
         'no-array-component-field-type': 'off',
-        'no-regex-duplicates': 'off'
+        'no-regex-duplicates': 'off',
+        'for-terminator-style': 'end-for'
     };
 }
 
@@ -170,7 +171,8 @@ function rulesToSeverity(rules: BsLintConfig['rules']) {
         colorCertCompliant: rules['color-cert'],
         noAssocarrayComponentFieldType: ruleToSeverity(rules['no-assocarray-component-field-type']),
         noArrayComponentFieldType: ruleToSeverity(rules['no-array-component-field-type']),
-        noRegexDuplicates: ruleToSeverity(rules['no-regex-duplicates'])
+        noRegexDuplicates: ruleToSeverity(rules['no-regex-duplicates']),
+        forTerminatorStyle: rules['for-terminator-style']
     };
 }
 


### PR DESCRIPTION
## Summary
- New `for-terminator-style` rule (`'end-for' | 'next' | 'off'`, default `'end-for'`) flags inconsistent terminators on `for` / `for each` loops.
- Code actions in both directions (`Convert to end for` / `Convert to next`) — replace just the terminator token, preserving indentation and any trailing comment.
- `WhileStatement` is unaffected (the parser does not accept `next` for `while`); nested loops are flagged and fixed independently.