### PR TITLE
Make sure scope-based diagnostics are cleared when needed

### DIFF
--- a/src/Linter.ts
+++ b/src/Linter.ts
@@ -2,7 +2,9 @@ import { BsLintConfig } from './index';
 import { ProgramBuilder, BsConfig } from 'brighterscript';
 
 export const BsLintDiagnosticTag = 'BSLint';
+export const BsLintScopeDiagnosticTag = 'BSLint_Scope';
 export const BsLintDiagnosticContext = { tags: [BsLintDiagnosticTag] };
+export const BsLintScopeDiagnosticContext = { tags: [BsLintDiagnosticTag, BsLintScopeDiagnosticTag] };
 
 
 const pendingJobs: Promise<void>[] = [];

--- a/src/plugins/trackCodeFlow/index.spec.ts
+++ b/src/plugins/trackCodeFlow/index.spec.ts
@@ -7,6 +7,7 @@ import bslintFactory from '../../index';
 import { createContext, PluginWrapperContext } from '../../util';
 import { expectDiagnostics, fmtDiagnostics } from '../../testHelpers.spec';
 import { VarLintError } from './varTracking';
+import * as path from 'path';
 
 describe('trackCodeFlow', () => {
     let linter: Linter;
@@ -196,8 +197,8 @@ describe('trackCodeFlow', () => {
             program.validate();
             const actual = fmtDiagnostics(program.getDiagnostics());
             const expected = [
-                `05:LINT1001:Using uninitialised variable 'doThing' when this file is included in scope 'components/Comp.xml'`,
-                `05:LINT1001:Using uninitialised variable 'doThing' when this file is included in scope 'components/Comp2.xml'`,
+                `05:LINT1001:Using uninitialised variable 'doThing' when this file is included in scope 'components${path.sep}Comp.xml'`,
+                `05:LINT1001:Using uninitialised variable 'doThing' when this file is included in scope 'components${path.sep}Comp2.xml'`,
                 `05:cannot-find-function:Cannot find function 'doThing'`,
                 `05:cannot-find-function:Cannot find function 'doThing'`
             ];

--- a/src/plugins/trackCodeFlow/index.spec.ts
+++ b/src/plugins/trackCodeFlow/index.spec.ts
@@ -160,6 +160,59 @@ describe('trackCodeFlow', () => {
         });
     });
 
+    describe('removes uninitialized var diagnostics after dependent code updates', () => {
+        it('after fixing uninitialized var', () => {
+            program.setFile('components/Comp.xml', `<?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <script uri="Comp.bs"/>
+                </component>
+            `);
+            program.setFile('components/Comp.bs', `
+                import "pkg:/source/common.bs"
+
+                sub init()
+                    print doThing()
+                end sub
+            `);
+
+            program.setFile('components/Comp2.xml', `<?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp2" extends="Group">
+                    <script uri="Comp2.bs"/>
+                </component>
+            `);
+            program.setFile('components/Comp2.bs', `
+                import "pkg:/source/common.bs"
+
+                sub init()
+                    print doThing()
+                end sub
+            `);
+
+            program.setFile('source/common.bs', `
+                function doOtherThing() as string
+                    return "hello"
+                end function
+            `);
+            program.validate();
+            const actual = fmtDiagnostics(program.getDiagnostics());
+            const expected = [
+                `05:LINT1001:Using uninitialised variable 'doThing' when this file is included in scope 'components/Comp.xml'`,
+                `05:LINT1001:Using uninitialised variable 'doThing' when this file is included in scope 'components/Comp2.xml'`,
+                `05:cannot-find-function:Cannot find function 'doThing'`,
+                `05:cannot-find-function:Cannot find function 'doThing'`
+            ];
+            expect(actual).deep.equal(expected);
+
+            program.setFile('source/common.bs', `
+                function doThing() as string
+                    return "hello"
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, []);
+        });
+    });
+
     describe('namespaced functions', () => {
         it('does not mark as uninitialised vars when used within namespace', async () => {
             const diagnostics = await linter.run({

--- a/src/plugins/trackCodeFlow/index.ts
+++ b/src/plugins/trackCodeFlow/index.ts
@@ -4,7 +4,7 @@ import { createReturnLinter } from './returnTracking';
 import { createVarLinter, resetVarContext, runDeferredValidation } from './varTracking';
 import { extractFixes } from './trackFixes';
 import { addFixesToEvent } from '../../textEdit';
-import { BsLintDiagnosticContext } from '../../Linter';
+import { BsLintDiagnosticContext, BsLintScopeDiagnosticContext, BsLintScopeDiagnosticTag } from '../../Linter';
 import type { Location } from 'vscode-languageserver-types'; // TODO: Get this from brighterscript
 
 export interface NarrowingInfo {
@@ -67,10 +67,11 @@ export default class TrackCodeFlow implements CompilerPlugin {
 
     afterValidateScope(event: AfterValidateScopeEvent) {
         const { scope } = event;
+        event.program.diagnostics.clearByFilter({ tag: BsLintScopeDiagnosticTag, scope: scope });
         const callablesMap = util.getCallableContainersByLowerName(scope.getAllCallables());
         const diagnostics = runDeferredValidation(this.lintContext, scope, scope.getAllFiles(), callablesMap);
         event.program.diagnostics.register(diagnostics as any, {
-            ...BsLintDiagnosticContext,
+            ...BsLintScopeDiagnosticContext,
             scope: scope
         });
     }


### PR DESCRIPTION
Scope-based diagnostics were not being cleared on re-running scope validation. This meant that previous diagnostics, even if not applicable anymore, were still visible.

