### PR TITLE
Changes Diagnostics to use human-readable codes

### DIFF
--- a/src/plugins/checkUsage/index.spec.ts
+++ b/src/plugins/checkUsage/index.spec.ts
@@ -51,8 +51,8 @@ describe('checkUsage', () => {
             }
         });
         expectDiagnosticsFmt(diagnostics, [
-            `01:LINT4002:Script 'components${path.sep}child2.brs' does not seem to be used`,
-            `02:LINT4001:Component 'components${path.sep}child2.xml' does not seem to be used`
+            `01:unused-script:Script 'components${path.sep}child2.brs' does not seem to be used`,
+            `02:unused-component:Component 'components${path.sep}child2.xml' does not seem to be used`
         ]);
     });
 });

--- a/src/plugins/checkUsage/index.ts
+++ b/src/plugins/checkUsage/index.ts
@@ -6,6 +6,11 @@ import { BsLintDiagnosticContext } from '../../Linter';
 const isWin = process.platform === 'win32';
 
 export enum UnusedCode {
+    UnusedComponent = 'unused-component',
+    UnusedScript = 'unused-script'
+}
+
+export enum UnusedLegacyCode {
     UnusedComponent = 'LINT4001',
     UnusedScript = 'LINT4002'
 }

--- a/src/plugins/codeStyle/diagnosticMessages.ts
+++ b/src/plugins/codeStyle/diagnosticMessages.ts
@@ -1,6 +1,6 @@
 import { DiagnosticSeverity, FunctionExpression, IfStatement, Location, WhileStatement } from 'brighterscript';
 
-export enum CodeStyleError {
+export enum CodeStyleLegacyError {
     InlineIfFound = 'LINT3001',
     InlineIfThenMissing = 'LINT3002',
     InlineIfThenFound = 'LINT3003',
@@ -32,6 +32,39 @@ export enum CodeStyleError {
     ForTerminatorNextExpected = 'LINT3028'
 }
 
+export enum CodeStyleError {
+    InlineIfFound = 'inline-if-found',
+    InlineIfThenMissing = 'missing-inline-if-then',
+    InlineIfThenFound = 'inline-if-then-found',
+    BlockIfThenMissing = 'missing-block-if-then',
+    BlockIfThenFound = 'block-if-then-found',
+    ConditionGroupMissing = 'missing-condition-group',
+    ConditionGroupFound = 'condition-group-found',
+    SubKeywordExpected = 'missing-sub-keyword',
+    FunctionKeywordExpected = 'missing-function-keyword',
+    ReturnTypeAnnotation = 'missing-return-type',
+    TypeAnnotation = 'missing-type',
+    NoPrint = 'no-print',
+    AACommaFound = 'aa-comma-found',
+    AACommaMissing = 'missing-aa-comma',
+    NoTodo = 'no-todo',
+    NoStop = 'no-stop',
+    EolLastMissing = 'missing-eol-last',
+    EolLastFound = 'eol-last-found',
+    ColorFormat = 'color-format',
+    ColorCase = 'color-case',
+    ColorAlpha = 'color-alpha',
+    ColorAlphaDefaults = 'color-alpha-defaults',
+    ColorCertCompliant = 'color-cert-compliant',
+    NoAssocarrayFieldType = 'no-assocarray-field-type',
+    NoArrayFieldType = 'no-array-field-type',
+    NoRegexDuplicates = 'no-regex-duplicates',
+    NameShadowing = 'name-shadowing',
+    TypeReassignment = 'type-reassignment',
+    ForTerminatorEndForExpected = 'missing-end-for',
+    ForTerminatorNextExpected = 'missing-next'
+}
+
 const CS = 'Code style:';
 const ST = 'Strictness:';
 
@@ -39,6 +72,7 @@ export const messages = {
     addBlockIfThenKeyword: (stat: IfStatement) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.BlockIfThenMissing,
+        legacyCode: CodeStyleLegacyError.BlockIfThenMissing,
         source: 'bslint',
         message: `${CS} add 'then' keyword`,
         location: stat.tokens.if.location,
@@ -47,6 +81,7 @@ export const messages = {
     removeBlockIfThenKeyword: (stat: IfStatement) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.BlockIfThenFound,
+        legacyCode: CodeStyleLegacyError.BlockIfThenFound,
         source: 'bslint',
         message: `${CS} remove 'then' keyword`,
         location: stat.tokens.then.location,
@@ -55,6 +90,7 @@ export const messages = {
     inlineIfNotAllowed: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.InlineIfFound,
+        legacyCode: CodeStyleLegacyError.InlineIfFound,
         source: 'bslint',
         message: `${CS} no inline if statement allowed`,
         location
@@ -62,6 +98,7 @@ export const messages = {
     addInlineIfThenKeyword: (stat: IfStatement) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.InlineIfThenMissing,
+        legacyCode: CodeStyleLegacyError.InlineIfThenMissing,
         source: 'bslint',
         message: `${CS} add 'then' keyword`,
         location: stat.tokens.if.location,
@@ -70,6 +107,7 @@ export const messages = {
     removeInlineIfThenKeyword: (stat: IfStatement) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.InlineIfThenFound,
+        legacyCode: CodeStyleLegacyError.InlineIfThenFound,
         source: 'bslint',
         message: `${CS} remove 'then' keyword`,
         location: stat.tokens.then.location,
@@ -78,6 +116,7 @@ export const messages = {
     addParenthesisAroundCondition: (stat: IfStatement | WhileStatement) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ConditionGroupMissing,
+        legacyCode: CodeStyleLegacyError.ConditionGroupMissing,
         source: 'bslint',
         message: `${CS} add parenthesis around condition`,
         location: stat.condition.location,
@@ -86,6 +125,7 @@ export const messages = {
     removeParenthesisAroundCondition: (stat: IfStatement | WhileStatement) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ConditionGroupFound,
+        legacyCode: CodeStyleLegacyError.ConditionGroupFound,
         source: 'bslint',
         message: `${CS} remove parenthesis around condition`,
         location: stat.condition.location,
@@ -94,6 +134,7 @@ export const messages = {
     expectedSubKeyword: (fun: FunctionExpression, reason: string) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.SubKeywordExpected,
+        legacyCode: CodeStyleLegacyError.SubKeywordExpected,
         source: 'bslint',
         message: `${CS} expected 'sub' keyword ${reason}`,
         location: fun.tokens.functionType.location,
@@ -102,6 +143,7 @@ export const messages = {
     expectedFunctionKeyword: (fun: FunctionExpression, reason: string) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.FunctionKeywordExpected,
+        legacyCode: CodeStyleLegacyError.FunctionKeywordExpected,
         source: 'bslint',
         message: `${CS} expected 'function' keyword ${reason}`,
         location: fun.tokens.functionType.location,
@@ -110,6 +152,7 @@ export const messages = {
     expectedReturnTypeAnnotation: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ReturnTypeAnnotation,
+        legacyCode: CodeStyleLegacyError.ReturnTypeAnnotation,
         source: 'bslint',
         message: `${ST} function should declare the return type`,
         location
@@ -117,6 +160,7 @@ export const messages = {
     expectedTypeAnnotation: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.TypeAnnotation,
+        legacyCode: CodeStyleLegacyError.TypeAnnotation,
         source: 'bslint',
         message: `${ST} type annotation required`,
         location
@@ -124,6 +168,7 @@ export const messages = {
     noPrint: (location: Location, severity: DiagnosticSeverity) => ({
         severity: severity,
         code: CodeStyleError.NoPrint,
+        legacyCode: CodeStyleLegacyError.NoPrint,
         source: 'bslint',
         message: `${CS} Avoid using direct Print statements`,
         location
@@ -131,6 +176,7 @@ export const messages = {
     noTodo: (location: Location, severity: DiagnosticSeverity) => ({
         severity: severity,
         code: CodeStyleError.NoTodo,
+        legacyCode: CodeStyleLegacyError.NoTodo,
         source: 'bslint',
         message: `${CS} Avoid using TODO comments`,
         location
@@ -138,6 +184,7 @@ export const messages = {
     noStop: (location: Location, severity: DiagnosticSeverity) => ({
         severity: severity,
         code: CodeStyleError.NoStop,
+        legacyCode: CodeStyleLegacyError.NoStop,
         source: 'bslint',
         message: `${CS} STOP statements are not allowed in published applications`,
         location
@@ -145,6 +192,7 @@ export const messages = {
     removeAAComma: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.AACommaFound,
+        legacyCode: CodeStyleLegacyError.AACommaFound,
         source: 'bslint',
         message: `Remove optional comma`,
         location
@@ -152,6 +200,7 @@ export const messages = {
     addAAComma: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.AACommaMissing,
+        legacyCode: CodeStyleLegacyError.AACommaMissing,
         source: 'bslint',
         message: `Add comma after the expression`,
         location
@@ -159,6 +208,7 @@ export const messages = {
     addEolLast: (location: Location, preferredEol: string) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.EolLastMissing,
+        legacyCode: CodeStyleLegacyError.EolLastMissing,
         source: 'bslint',
         message: `${CS} File should end with a newline`,
         location,
@@ -167,6 +217,7 @@ export const messages = {
     removeEolLast: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.EolLastFound,
+        legacyCode: CodeStyleLegacyError.EolLastFound,
         source: 'bslint',
         message: `${CS} File should not end with a newline`,
         location
@@ -174,6 +225,7 @@ export const messages = {
     expectedColorFormat: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ColorFormat,
+        legacyCode: CodeStyleLegacyError.ColorFormat,
         source: 'bslint',
         message: `${CS} File should follow color format`,
         location
@@ -181,6 +233,7 @@ export const messages = {
     expectedColorCase: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ColorCase,
+        legacyCode: CodeStyleLegacyError.ColorCase,
         source: 'bslint',
         message: `${CS} File should follow color case`,
         location
@@ -188,6 +241,7 @@ export const messages = {
     expectedColorAlpha: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ColorAlpha,
+        legacyCode: CodeStyleLegacyError.ColorAlpha,
         source: 'bslint',
         message: `${CS} File should follow color alpha rule`,
         location
@@ -195,6 +249,7 @@ export const messages = {
     expectedColorAlphaDefaults: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ColorAlphaDefaults,
+        legacyCode: CodeStyleLegacyError.ColorAlphaDefaults,
         source: 'bslint',
         message: `${CS} File should follow color alpha defaults rule`,
         location
@@ -202,6 +257,7 @@ export const messages = {
     colorCertCompliance: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ColorCertCompliant,
+        legacyCode: CodeStyleLegacyError.ColorCertCompliant,
         source: 'bslint',
         message: `${CS} File should follow Roku broadcast safe color cert requirement`,
         location
@@ -209,6 +265,7 @@ export const messages = {
     noAssocarrayFieldType: (location: Location, severity: DiagnosticSeverity) => ({
         message: `Avoid using field type 'assocarray'`,
         code: CodeStyleError.NoAssocarrayFieldType,
+        legacyCode: CodeStyleLegacyError.NoAssocarrayFieldType,
         severity: severity,
         source: 'bslint',
         location
@@ -216,6 +273,7 @@ export const messages = {
     noArrayFieldType: (location: Location, severity: DiagnosticSeverity) => ({
         message: `Avoid using field type 'array'`,
         code: CodeStyleError.NoArrayFieldType,
+        legacyCode: CodeStyleLegacyError.NoArrayFieldType,
         severity: severity,
         source: 'bslint',
         location
@@ -223,12 +281,13 @@ export const messages = {
     nameShadowing: (thisThingKind: string, thatThingKind: string, thatThingName: string, severity: DiagnosticSeverity) => ({
         message: `${ST} ${thisThingKind} has same name as ${thatThingKind ? thatThingKind + ' ' : ''}'${thatThingName}'`,
         code: CodeStyleError.NameShadowing,
+        legacyCode: CodeStyleLegacyError.NameShadowing,
         severity: severity,
         source: 'bslint'
     }),
     typeReassignment: (location: Location, varName: string, previousType: string, newType: string, severity: DiagnosticSeverity) => ({
         message: `${ST} Reassignment of the type of '${varName}' from ${previousType} to ${newType}`,
-        code: CodeStyleError.NameShadowing,
+        code: CodeStyleError.TypeReassignment,
         severity: severity,
         source: 'bslint',
         location
@@ -236,6 +295,7 @@ export const messages = {
     noIdenticalRegexInLoop: (location: Location, severity: DiagnosticSeverity) => ({
         message: 'Avoid redeclaring identical regular expressions in a loop',
         code: CodeStyleError.NoRegexDuplicates,
+        legacyCode: CodeStyleLegacyError.NoRegexDuplicates,
         severity: severity,
         source: 'bslint',
         location
@@ -243,6 +303,7 @@ export const messages = {
     noRegexRedeclaring: (location: Location, severity: DiagnosticSeverity) => ({
         message: 'Avoid redeclaring identical regular expressions',
         code: CodeStyleError.NoRegexDuplicates,
+        legacyCode: CodeStyleLegacyError.NoRegexDuplicates,
         severity: severity,
         source: 'bslint',
         location
@@ -250,6 +311,7 @@ export const messages = {
     expectedEndForTerminator: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ForTerminatorEndForExpected,
+        legacyCode: CodeStyleLegacyError.ForTerminatorEndForExpected,
         source: 'bslint',
         message: `${CS} expected 'end for' terminator`,
         location
@@ -257,6 +319,7 @@ export const messages = {
     expectedNextTerminator: (location: Location) => ({
         severity: DiagnosticSeverity.Error,
         code: CodeStyleError.ForTerminatorNextExpected,
+        legacyCode: CodeStyleLegacyError.ForTerminatorNextExpected,
         source: 'bslint',
         message: `${CS} expected 'next' terminator`,
         location

--- a/src/plugins/codeStyle/index.spec.ts
+++ b/src/plugins/codeStyle/index.spec.ts
@@ -105,8 +105,8 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `02:LINT3001:Code style: no inline if statement allowed`,
-                `06:LINT3001:Code style: no inline if statement allowed`
+                `02:inline-if-found:Code style: no inline if statement allowed`,
+                `06:inline-if-found:Code style: no inline if statement allowed`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -124,7 +124,7 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `06:LINT3002:Code style: add 'then' keyword`
+                `06:missing-inline-if-then:Code style: add 'then' keyword`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -142,7 +142,7 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `02:LINT3003:Code style: remove 'then' keyword`
+                `02:inline-if-then-found:Code style: remove 'then' keyword`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -179,8 +179,8 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `10:LINT3004:Code style: add 'then' keyword`,
-                `12:LINT3004:Code style: add 'then' keyword`
+                `10:missing-block-if-then:Code style: add 'then' keyword`,
+                `12:missing-block-if-then:Code style: add 'then' keyword`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -198,8 +198,8 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `02:LINT3005:Code style: remove 'then' keyword`,
-                `04:LINT3005:Code style: remove 'then' keyword`
+                `02:block-if-then-found:Code style: remove 'then' keyword`,
+                `04:block-if-then-found:Code style: remove 'then' keyword`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -236,8 +236,8 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `03:LINT3006:Code style: add parenthesis around condition`,
-                `05:LINT3006:Code style: add parenthesis around condition`
+                `03:missing-condition-group:Code style: add parenthesis around condition`,
+                `05:missing-condition-group:Code style: add parenthesis around condition`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -255,8 +255,8 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `12:LINT3007:Code style: remove parenthesis around condition`,
-                `14:LINT3007:Code style: remove parenthesis around condition`
+                `12:condition-group-found:Code style: remove parenthesis around condition`,
+                `14:condition-group-found:Code style: remove parenthesis around condition`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -305,9 +305,9 @@ describe('codeStyle', () => {
             program.setFile('source/main.brs', mixedSource);
             program.validate();
             expectDiagnosticsFmt(program, [
-                `09:LINT3027:Code style: expected 'end for' terminator`,
-                `17:LINT3027:Code style: expected 'end for' terminator`,
-                `26:LINT3027:Code style: expected 'end for' terminator`
+                `09:missing-end-for:Code style: expected 'end for' terminator`,
+                `17:missing-end-for:Code style: expected 'end for' terminator`,
+                `26:missing-end-for:Code style: expected 'end for' terminator`
             ]);
         });
 
@@ -316,9 +316,9 @@ describe('codeStyle', () => {
             program.setFile('source/main.brs', mixedSource);
             program.validate();
             expectDiagnosticsFmt(program, [
-                `05:LINT3028:Code style: expected 'next' terminator`,
-                `13:LINT3028:Code style: expected 'next' terminator`,
-                `27:LINT3028:Code style: expected 'next' terminator`
+                `05:missing-next:Code style: expected 'next' terminator`,
+                `13:missing-next:Code style: expected 'next' terminator`,
+                `27:missing-next:Code style: expected 'next' terminator`
             ]);
         });
 
@@ -351,12 +351,12 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                `06:LINT3027:Code style: expected 'end for' terminator`
+                `06:missing-end-for:Code style: expected 'end for' terminator`
             ]);
         });
 
         function applyAllFixes(src: string, code: string): string {
-            const diagnostics = program.getDiagnostics().filter(d => d.code === code);
+            const diagnostics = program.getDiagnostics().filter(d => d.code === code || d.legacyCode === code);
             const allChanges = diagnostics.flatMap(d => getFixes(d as any).changes);
             return applyEdits(src, allChanges);
         }
@@ -366,7 +366,7 @@ describe('codeStyle', () => {
             program.setFile('source/main.brs', mixedSource);
             program.validate();
 
-            const fixed = applyAllFixes(mixedSource, 'LINT3027');
+            const fixed = applyAllFixes(mixedSource, 'missing-end-for');
             const expected = `
             sub test()
                 for i = 0 to 5
@@ -404,7 +404,7 @@ describe('codeStyle', () => {
             program.setFile('source/main.brs', mixedSource);
             program.validate();
 
-            const fixed = applyAllFixes(mixedSource, 'LINT3028');
+            const fixed = applyAllFixes(mixedSource, 'missing-next');
             const expected = `
             sub test()
                 for i = 0 to 5
@@ -449,7 +449,7 @@ describe('codeStyle', () => {
             program.setFile('source/main.brs', src);
             program.validate();
 
-            const fixed = applyAllFixes(src, 'LINT3027');
+            const fixed = applyAllFixes(src, 'missing-end-for');
             // 'next' replaced in place; preceding indent and trailing comment stay
             expect(fixed).to.contain(`                    end for ' done iterating\n`);
         });
@@ -468,7 +468,7 @@ describe('codeStyle', () => {
             program.setFile('source/main.brs', src);
             program.validate();
 
-            const fixed = applyAllFixes(src, 'LINT3027');
+            const fixed = applyAllFixes(src, 'missing-end-for');
             // outer 'end for' was already correct; inner 'next' became 'end for'
             const innerEndFor = fixed.indexOf('                        end for');
             const outerEndFor = fixed.indexOf('                    end for');
@@ -491,9 +491,9 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `08:LINT3008:Code style: expected 'sub' keyword (always use 'sub')`,
-                `10:LINT3008:Code style: expected 'sub' keyword (always use 'sub')`,
-                `16:LINT3008:Code style: expected 'sub' keyword (always use 'sub')`
+                `08:missing-sub-keyword:Code style: expected 'sub' keyword (always use 'sub')`,
+                `10:missing-sub-keyword:Code style: expected 'sub' keyword (always use 'sub')`,
+                `16:missing-sub-keyword:Code style: expected 'sub' keyword (always use 'sub')`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -510,8 +510,8 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `08:LINT3009:Code style: expected 'function' keyword (always use 'function')`,
-                `10:LINT3009:Code style: expected 'function' keyword (always use 'function')`
+                `08:missing-function-keyword:Code style: expected 'function' keyword (always use 'function')`,
+                `10:missing-function-keyword:Code style: expected 'function' keyword (always use 'function')`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -529,16 +529,16 @@ describe('codeStyle', () => {
             } as any);
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `22:LINT3009:Code style: expected 'function' keyword (use 'function' when a value is returned)`,
-                `23:LINT3009:Code style: expected 'function' keyword (use 'function' when a value is returned)`,
+                `22:missing-function-keyword:Code style: expected 'function' keyword (use 'function' when a value is returned)`,
+                `23:missing-function-keyword:Code style: expected 'function' keyword (use 'function' when a value is returned)`,
                 `24:return-type-mismatch:Type 'string' is not compatible with declared return type 'void' '`,
                 `24:unexpected-return-value:Void sub may not return a value`,
                 `26:return-type-mismatch:Type 'string' is not compatible with declared return type 'void' '`,
                 `26:unexpected-return-value:Void sub may not return a value`,
-                `29:LINT3008:Code style: expected 'sub' keyword (use 'sub' when no value is returned)`,
-                `31:LINT3008:Code style: expected 'sub' keyword (use 'sub' when no value is returned)`,
-                `36:LINT3008:Code style: expected 'sub' keyword (use 'sub' when no value is returned)`,
-                `38:LINT3008:Code style: expected 'sub' keyword (use 'sub' when no value is returned)`
+                `29:missing-sub-keyword:Code style: expected 'sub' keyword (use 'sub' when no value is returned)`,
+                `31:missing-sub-keyword:Code style: expected 'sub' keyword (use 'sub' when no value is returned)`,
+                `36:missing-sub-keyword:Code style: expected 'sub' keyword (use 'sub' when no value is returned)`,
+                `38:missing-sub-keyword:Code style: expected 'sub' keyword (use 'sub' when no value is returned)`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -574,7 +574,7 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `05:LINT3010:Strictness: function should declare the return type`
+                `05:missing-return-type:Strictness: function should declare the return type`
             ];
             expect(actual).deep.equal(expected);
             // should only highlight the function name
@@ -596,9 +596,9 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `01:LINT3011:Strictness: type annotation required`,
-                `05:LINT3011:Strictness: type annotation required`,
-                `13:LINT3011:Strictness: type annotation required`
+                `01:missing-type:Strictness: type annotation required`,
+                `05:missing-type:Strictness: type annotation required`,
+                `13:missing-type:Strictness: type annotation required`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -616,10 +616,10 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `01:LINT3011:Strictness: type annotation required`,
-                `05:LINT3010:Strictness: function should declare the return type`,
-                `05:LINT3011:Strictness: type annotation required`,
-                `13:LINT3011:Strictness: type annotation required`
+                `01:missing-type:Strictness: type annotation required`,
+                `05:missing-return-type:Strictness: function should declare the return type`,
+                `05:missing-type:Strictness: type annotation required`,
+                `13:missing-type:Strictness: type annotation required`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -637,10 +637,10 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `01:LINT3011:Strictness: type annotation required`,
-                `05:LINT3010:Strictness: function should declare the return type`,
-                `05:LINT3011:Strictness: type annotation required`,
-                `17:LINT3010:Strictness: function should declare the return type`
+                `01:missing-type:Strictness: type annotation required`,
+                `05:missing-return-type:Strictness: function should declare the return type`,
+                `05:missing-type:Strictness: type annotation required`,
+                `17:missing-return-type:Strictness: function should declare the return type`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -659,8 +659,8 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `01:LINT3011:Strictness: type annotation required`,
-                `05:LINT3011:Strictness: type annotation required`
+                `01:missing-type:Strictness: type annotation required`,
+                `05:missing-type:Strictness: type annotation required`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -677,8 +677,8 @@ describe('codeStyle', () => {
         });
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `02:LINT3012:Code style: Avoid using direct Print statements`,
-            `03:LINT3012:Code style: Avoid using direct Print statements`
+            `02:no-print:Code style: Avoid using direct Print statements`,
+            `03:no-print:Code style: Avoid using direct Print statements`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -711,12 +711,12 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `02:LINT3015:Code style: Avoid using TODO comments`,
-                `04:LINT3015:Code style: Avoid using TODO comments`,
-                `06:LINT3015:Code style: Avoid using TODO comments`,
-                `08:LINT3015:Code style: Avoid using TODO comments`,
-                '10:LINT3015:Code style: Avoid using TODO comments',
-                '12:LINT3015:Code style: Avoid using TODO comments'
+                `02:no-todo:Code style: Avoid using TODO comments`,
+                `04:no-todo:Code style: Avoid using TODO comments`,
+                `06:no-todo:Code style: Avoid using TODO comments`,
+                `08:no-todo:Code style: Avoid using TODO comments`,
+                '10:no-todo:Code style: Avoid using TODO comments',
+                '12:no-todo:Code style: Avoid using TODO comments'
             ];
             expect(actual).deep.equal(expected);
         });
@@ -731,7 +731,7 @@ describe('codeStyle', () => {
                 }
             });
             const actual = fmtDiagnostics(diagnostics);
-            const expected = ['19:LINT3015:Code style: Avoid using TODO comments'];
+            const expected = ['19:no-todo:Code style: Avoid using TODO comments'];
             expect(actual).deep.equal(expected);
         });
     });
@@ -746,7 +746,7 @@ describe('codeStyle', () => {
         });
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `03:LINT3016:Code style: STOP statements are not allowed in published applications`
+            `03:no-stop:Code style: STOP statements are not allowed in published applications`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -762,7 +762,7 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `03:LINT3017:Code style: File should end with a newline`
+                `03:missing-eol-last:Code style: File should end with a newline`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -777,7 +777,7 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `03:LINT3018:Code style: File should not end with a newline`
+                `03:eol-last-found:Code style: File should not end with a newline`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -832,8 +832,8 @@ describe('codeStyle', () => {
         } as any);
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `06:LINT3024:Avoid using field type 'assocarray'`,
-            `07:LINT3024:Avoid using field type 'assocarray'`
+            `06:no-assocarray-field-type:Avoid using field type 'assocarray'`,
+            `07:no-assocarray-field-type:Avoid using field type 'assocarray'`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -848,8 +848,8 @@ describe('codeStyle', () => {
         } as any);
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `04:LINT3025:Avoid using field type 'array'`,
-            `08:LINT3025:Avoid using field type 'array'`
+            `04:no-array-field-type:Avoid using field type 'array'`,
+            `08:no-array-field-type:Avoid using field type 'array'`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -906,12 +906,12 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `03:LINT3013:Remove optional comma`,
-                `04:LINT3013:Remove optional comma`,
-                `11:LINT3013:Remove optional comma`,
-                `12:LINT3013:Remove optional comma`,
-                `13:LINT3013:Remove optional comma`,
-                `31:LINT3013:Remove optional comma`
+                `03:aa-comma-found:Remove optional comma`,
+                `04:aa-comma-found:Remove optional comma`,
+                `11:aa-comma-found:Remove optional comma`,
+                `12:aa-comma-found:Remove optional comma`,
+                `13:aa-comma-found:Remove optional comma`,
+                `31:aa-comma-found:Remove optional comma`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -926,10 +926,10 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `13:LINT3013:Remove optional comma`,
-                `19:LINT3014:Add comma after the expression`,
-                `20:LINT3014:Add comma after the expression`,
-                `31:LINT3013:Remove optional comma`
+                `13:aa-comma-found:Remove optional comma`,
+                `19:missing-aa-comma:Add comma after the expression`,
+                `20:missing-aa-comma:Add comma after the expression`,
+                `31:aa-comma-found:Remove optional comma`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -944,11 +944,11 @@ describe('codeStyle', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `05:LINT3014:Add comma after the expression`,
-                `19:LINT3014:Add comma after the expression`,
-                `20:LINT3014:Add comma after the expression`,
-                `21:LINT3014:Add comma after the expression`,
-                `31:LINT3013:Remove optional comma`
+                `05:missing-aa-comma:Add comma after the expression`,
+                `19:missing-aa-comma:Add comma after the expression`,
+                `20:missing-aa-comma:Add comma after the expression`,
+                `21:missing-aa-comma:Add comma after the expression`,
+                `31:aa-comma-found:Remove optional comma`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -976,8 +976,8 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '05:LINT3026:Avoid redeclaring identical regular expressions in a loop',
-                '11:LINT3026:Avoid redeclaring identical regular expressions in a loop'
+                '05:no-regex-duplicates:Avoid redeclaring identical regular expressions in a loop',
+                '11:no-regex-duplicates:Avoid redeclaring identical regular expressions in a loop'
             ]);
         });
 
@@ -1014,7 +1014,7 @@ describe('codeStyle', () => {
                 end sub
             `);
             program.validate();
-            expectDiagnosticsFmt(program, ['08:LINT3026:Avoid redeclaring identical regular expressions']);
+            expectDiagnosticsFmt(program, ['08:no-regex-duplicates:Avoid redeclaring identical regular expressions']);
         });
 
 
@@ -1064,7 +1064,7 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '03:LINT3020:Code style: File should follow color case'
+                '03:color-case:Code style: File should follow color case'
             ]);
         });
 
@@ -1085,7 +1085,7 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '05:LINT3020:Code style: File should follow color case'
+                '05:color-case:Code style: File should follow color case'
             ]);
         });
 
@@ -1107,8 +1107,8 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '04:LINT3020:Code style: File should follow color case',
-                '07:LINT3020:Code style: File should follow color case'
+                '04:color-case:Code style: File should follow color case',
+                '07:color-case:Code style: File should follow color case'
             ]);
         });
 
@@ -1148,9 +1148,9 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '04:LINT3019:Code style: File should follow color format',
-                '05:LINT3019:Code style: File should follow color format',
-                '06:LINT3019:Code style: File should follow color format'
+                '04:color-format:Code style: File should follow color format',
+                '05:color-format:Code style: File should follow color format',
+                '06:color-format:Code style: File should follow color format'
             ]);
         });
 
@@ -1170,8 +1170,8 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '03:LINT3023:Code style: File should follow Roku broadcast safe color cert requirement',
-                '06:LINT3023:Code style: File should follow Roku broadcast safe color cert requirement'
+                '03:color-cert-compliant:Code style: File should follow Roku broadcast safe color cert requirement',
+                '06:color-cert-compliant:Code style: File should follow Roku broadcast safe color cert requirement'
             ]);
         });
 
@@ -1214,8 +1214,8 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '06:LINT3022:Code style: File should follow color alpha defaults rule',
-                '07:LINT3022:Code style: File should follow color alpha defaults rule'
+                '06:color-alpha-defaults:Code style: File should follow color alpha defaults rule',
+                '07:color-alpha-defaults:Code style: File should follow color alpha defaults rule'
             ]);
         });
 
@@ -1240,7 +1240,7 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '07:LINT3022:Code style: File should follow color alpha defaults rule'
+                '07:color-alpha-defaults:Code style: File should follow color alpha defaults rule'
             ]);
         });
 
@@ -1264,9 +1264,9 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '04:LINT3021:Code style: File should follow color alpha rule',
-                '06:LINT3021:Code style: File should follow color alpha rule',
-                '07:LINT3021:Code style: File should follow color alpha rule'
+                '04:color-alpha:Code style: File should follow color alpha rule',
+                '06:color-alpha:Code style: File should follow color alpha rule',
+                '07:color-alpha:Code style: File should follow color alpha rule'
             ]);
         });
 
@@ -1290,8 +1290,8 @@ describe('codeStyle', () => {
             `);
             program.validate();
             expectDiagnosticsFmt(program, [
-                '03:LINT3021:Code style: File should follow color alpha rule',
-                '05:LINT3021:Code style: File should follow color alpha rule'
+                '03:color-alpha:Code style: File should follow color alpha rule',
+                '05:color-alpha:Code style: File should follow color alpha rule'
             ]);
         });
     });
@@ -1306,11 +1306,11 @@ describe('codeStyle', () => {
                 }
             });
             expectDiagnosticsFmt(diagnostics, [
-                '15:LINT3127:Strictness: Class has same name as Class \'TestClass\'',
-                '18:LINT3127:Strictness: Enum has same name as Enum \'TestEnum\'',
-                '21:LINT3127:Strictness: Interface has same name as Interface \'TestInterface\'',
-                '24:LINT3127:Strictness: Const has same name as Const \'TestConst\'',
-                '26:LINT3127:Strictness: Const has same name as Namespace \'TestNamespace\''
+                '15:name-shadowing:Strictness: Class has same name as Class \'TestClass\'',
+                '18:name-shadowing:Strictness: Enum has same name as Enum \'TestEnum\'',
+                '21:name-shadowing:Strictness: Interface has same name as Interface \'TestInterface\'',
+                '24:name-shadowing:Strictness: Const has same name as Const \'TestConst\'',
+                '26:name-shadowing:Strictness: Const has same name as Namespace \'TestNamespace\''
             ]);
         });
 
@@ -1323,15 +1323,15 @@ describe('codeStyle', () => {
                 }
             });
             expectDiagnosticsFmt(diagnostics, [
-                '02:LINT3127:Strictness: Class has same name as Class \'TestImportClass\'',
-                '05:LINT3127:Strictness: Enum has same name as Enum \'TestImportEnum\'',
-                '08:LINT3127:Strictness: Interface has same name as Interface \'TestImportInterface\'',
-                '11:LINT3127:Strictness: Const has same name as Const \'TestImportConst\'',
-                '15:LINT3127:Strictness: Class has same name as Class \'TestClass\'',
-                '18:LINT3127:Strictness: Enum has same name as Enum \'TestEnum\'',
-                '21:LINT3127:Strictness: Interface has same name as Interface \'TestInterface\'',
-                '24:LINT3127:Strictness: Const has same name as Const \'TestConst\'',
-                '26:LINT3127:Strictness: Const has same name as Namespace \'TestNamespace\''
+                '02:name-shadowing:Strictness: Class has same name as Class \'TestImportClass\'',
+                '05:name-shadowing:Strictness: Enum has same name as Enum \'TestImportEnum\'',
+                '08:name-shadowing:Strictness: Interface has same name as Interface \'TestImportInterface\'',
+                '11:name-shadowing:Strictness: Const has same name as Const \'TestImportConst\'',
+                '15:name-shadowing:Strictness: Class has same name as Class \'TestClass\'',
+                '18:name-shadowing:Strictness: Enum has same name as Enum \'TestEnum\'',
+                '21:name-shadowing:Strictness: Interface has same name as Interface \'TestInterface\'',
+                '24:name-shadowing:Strictness: Const has same name as Const \'TestConst\'',
+                '26:name-shadowing:Strictness: Const has same name as Namespace \'TestNamespace\''
 
             ]);
         });
@@ -1345,8 +1345,8 @@ describe('codeStyle', () => {
                 }
             });
             expectDiagnosticsFmt(diagnostics, [
-                '02:LINT3127:Strictness: Const has same name as Function \'TestFunction\'',
-                '03:LINT3127:Strictness: Const has same name as Global Function \'Lcase\''
+                '02:name-shadowing:Strictness: Const has same name as Function \'TestFunction\'',
+                '03:name-shadowing:Strictness: Const has same name as Global Function \'Lcase\''
             ]);
         });
     });
@@ -1361,10 +1361,10 @@ describe('codeStyle', () => {
                 }
             });
             expectDiagnosticsFmt(diagnostics, [
-                '12:LINT3127:Strictness: Reassignment of the type of \'param\' from string to integer',
-                '18:LINT3127:Strictness: Reassignment of the type of \'value\' from integer to string',
-                '27:LINT3127:Strictness: Reassignment of the type of \'value\' from integer to dynamic',
-                '53:LINT3127:Strictness: Reassignment of the type of \'obj\' from integer to roAssociativeArray'
+                '12:type-reassignment:Strictness: Reassignment of the type of \'param\' from string to integer',
+                '18:type-reassignment:Strictness: Reassignment of the type of \'value\' from integer to string',
+                '27:type-reassignment:Strictness: Reassignment of the type of \'value\' from integer to dynamic',
+                '53:type-reassignment:Strictness: Reassignment of the type of \'obj\' from integer to roAssociativeArray'
             ]);
         });
 
@@ -1377,8 +1377,8 @@ describe('codeStyle', () => {
                 }
             });
             expectDiagnosticsFmt(diagnostics, [
-                '30:LINT3127:Strictness: Reassignment of the type of \'arg\' from Iface1 to roAssociativeArray',
-                '44:LINT3127:Strictness: Reassignment of the type of \'arg\' from Child to Parent'
+                '30:type-reassignment:Strictness: Reassignment of the type of \'arg\' from Iface1 to roAssociativeArray',
+                '44:type-reassignment:Strictness: Reassignment of the type of \'arg\' from Child to Parent'
             ]);
         });
     });
@@ -1723,7 +1723,7 @@ describe('codeStyle', () => {
                 end sub
             `);
             program.validate();
-            const diagnostics = program.getDiagnostics().filter(d => d.code === 'LINT3014');
+            const diagnostics = program.getDiagnostics().filter(d => d.code === 'missing-aa-comma');
             expect(diagnostics).to.have.length(1);
 
             const actions = getCodeActions('source/main.brs', diagnostics[0].location.range.start.line);
@@ -1743,7 +1743,7 @@ describe('codeStyle', () => {
                 end sub
             `);
             program.validate();
-            const diagnostics = program.getDiagnostics().filter(d => d.code === 'LINT3014');
+            const diagnostics = program.getDiagnostics().filter(d => d.code === 'missing-aa-comma');
             expect(diagnostics).to.have.length(2);
 
             const actions = getCodeActions('source/main.brs', diagnostics[0].location.range.start.line);
@@ -1762,7 +1762,7 @@ describe('codeStyle', () => {
                 end sub
             `);
             program.validate();
-            const diagnostics = program.getDiagnostics().filter(d => d.code === 'LINT3014');
+            const diagnostics = program.getDiagnostics().filter(d => d.code === 'missing-aa-comma');
             expect(diagnostics).to.have.length(3);
 
             const actions = getCodeActions('source/main.brs', diagnostics[0].location.range.start.line);
@@ -1788,7 +1788,7 @@ describe('codeStyle', () => {
                 end sub
             `);
             program.validate();
-            const diagnostics = program.getDiagnostics().filter(d => d.code === 'LINT3014');
+            const diagnostics = program.getDiagnostics().filter(d => d.code === 'missing-aa-comma');
             expect(diagnostics).to.have.length(4);
 
             // Only request actions at the first diagnostic — cursor is not near q1/q2

--- a/src/plugins/trackCodeFlow/index.spec.ts
+++ b/src/plugins/trackCodeFlow/index.spec.ts
@@ -70,10 +70,10 @@ describe('trackCodeFlow', () => {
         } as any);
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `02:LINT1001:Using uninitialised variable 'a' when this file is included in scope 'source'`,
-            `06:LINT1001:Using uninitialised variable 'a' when this file is included in scope 'source'`,
-            `10:LINT1001:Using uninitialised variable 'a' when this file is included in scope 'source'`,
-            `16:LINT1001:Using uninitialised variable 'a' when this file is included in scope 'source'`
+            `02:uninitialized-variable:Using uninitialised variable 'a' when this file is included in scope 'source'`,
+            `06:uninitialized-variable:Using uninitialised variable 'a' when this file is included in scope 'source'`,
+            `10:uninitialized-variable:Using uninitialised variable 'a' when this file is included in scope 'source'`,
+            `16:uninitialized-variable:Using uninitialised variable 'a' when this file is included in scope 'source'`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -197,10 +197,10 @@ describe('trackCodeFlow', () => {
             program.validate();
             const actual = fmtDiagnostics(program.getDiagnostics());
             const expected = [
-                `05:LINT1001:Using uninitialised variable 'doThing' when this file is included in scope 'components${path.sep}Comp.xml'`,
-                `05:LINT1001:Using uninitialised variable 'doThing' when this file is included in scope 'components${path.sep}Comp2.xml'`,
                 `05:cannot-find-function:Cannot find function 'doThing'`,
-                `05:cannot-find-function:Cannot find function 'doThing'`
+                `05:cannot-find-function:Cannot find function 'doThing'`,
+                `05:uninitialized-variable:Using uninitialised variable 'doThing' when this file is included in scope 'components${path.sep}Comp.xml'`,
+                `05:uninitialized-variable:Using uninitialised variable 'doThing' when this file is included in scope 'components${path.sep}Comp2.xml'`
             ];
             expect(actual).deep.equal(expected);
 
@@ -251,8 +251,8 @@ describe('trackCodeFlow', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `11:LINT1001:Using uninitialised variable 'one' when this file is included in scope 'source'`,
-                `11:cannot-find-function:Cannot find function 'one'`
+                `11:cannot-find-function:Cannot find function 'one'`,
+                `11:uninitialized-variable:Using uninitialised variable 'one' when this file is included in scope 'source'`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -267,8 +267,8 @@ describe('trackCodeFlow', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `18:LINT1001:Using uninitialised variable 'one' when this file is included in scope 'source'`,
-                `18:cannot-find-function:Cannot find function 'one'`
+                `18:cannot-find-function:Cannot find function 'one'`,
+                `18:uninitialized-variable:Using uninitialised variable 'one' when this file is included in scope 'source'`
             ];
             expect(actual).deep.equal(expected);
         });
@@ -287,15 +287,15 @@ describe('trackCodeFlow', () => {
         } as any);
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `06:LINT1003:Not all the code paths assign 'b'`,
-            `16:LINT1003:Not all the code paths assign 'b'`,
-            `25:LINT1003:Not all the code paths assign 'b'`,
-            `42:LINT1003:Not all the code paths assign 'b'`,
-            `51:LINT1003:Not all the code paths assign 'b'`,
-            `62:LINT1003:Not all the code paths assign 'b'`,
-            `71:LINT1003:Not all the code paths assign 'b'`,
-            `83:LINT1003:Not all the code paths assign 'b'`,
-            `85:LINT1003:Not all the code paths assign 'b'`
+            `06:unsafe-initialization:Not all the code paths assign 'b'`,
+            `16:unsafe-initialization:Not all the code paths assign 'b'`,
+            `25:unsafe-initialization:Not all the code paths assign 'b'`,
+            `42:unsafe-initialization:Not all the code paths assign 'b'`,
+            `51:unsafe-initialization:Not all the code paths assign 'b'`,
+            `62:unsafe-initialization:Not all the code paths assign 'b'`,
+            `71:unsafe-initialization:Not all the code paths assign 'b'`,
+            `83:unsafe-initialization:Not all the code paths assign 'b'`,
+            `85:unsafe-initialization:Not all the code paths assign 'b'`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -313,11 +313,11 @@ describe('trackCodeFlow', () => {
         } as any);
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `15:LINT1003:Not all the code paths assign 'a'`,
-            `23:LINT1003:Not all the code paths assign 'a'`,
-            `42:LINT1003:Not all the code paths assign 'a'`,
-            `65:LINT1003:Not all the code paths assign 'a'`,
-            `76:LINT1003:Not all the code paths assign 'a'`
+            `15:unsafe-initialization:Not all the code paths assign 'a'`,
+            `23:unsafe-initialization:Not all the code paths assign 'a'`,
+            `42:unsafe-initialization:Not all the code paths assign 'a'`,
+            `65:unsafe-initialization:Not all the code paths assign 'a'`,
+            `76:unsafe-initialization:Not all the code paths assign 'a'`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -336,8 +336,8 @@ describe('trackCodeFlow', () => {
         } as any);
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `18:LINT1003:Not all the code paths assign 'b'`,
-            `27:LINT1003:Not all the code paths assign 'b'`,
+            `18:unsafe-initialization:Not all the code paths assign 'b'`,
+            `27:unsafe-initialization:Not all the code paths assign 'b'`,
             `67:cannot-find-function:Cannot find function 'Bar'`,
             `67:not-constructable:Cannot use the 'new' keyword here because 'Bar' is not a constructable type`
         ];
@@ -356,8 +356,8 @@ describe('trackCodeFlow', () => {
         });
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `05:LINT1003:Not all the code paths assign 'a'`,
-            `15:LINT1003:Not all the code paths assign 'b'`
+            `05:unsafe-initialization:Not all the code paths assign 'a'`,
+            `15:unsafe-initialization:Not all the code paths assign 'b'`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -374,8 +374,8 @@ describe('trackCodeFlow', () => {
         });
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `05:LINT1002:Using iterator variable 'i' outside loop`,
-            `14:LINT1002:Using iterator variable 'a' outside loop`
+            `05:unsafe-iterator-variable:Using iterator variable 'i' outside loop`,
+            `14:unsafe-iterator-variable:Using iterator variable 'a' outside loop`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -391,8 +391,8 @@ describe('trackCodeFlow', () => {
         });
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `02:LINT1001:Using uninitialised variable 'err' when this file is included in scope 'source'`,
-            `08:LINT1001:Using uninitialised variable 'err' when this file is included in scope 'source'`
+            `02:uninitialized-variable:Using uninitialised variable 'err' when this file is included in scope 'source'`,
+            `08:uninitialized-variable:Using uninitialised variable 'err' when this file is included in scope 'source'`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -409,11 +409,11 @@ describe('trackCodeFlow', () => {
         });
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `04:LINT2001:Unreachable code`,
-            `10:LINT2001:Unreachable code`,
-            `26:LINT2001:Unreachable code`,
-            `41:LINT2001:Unreachable code`,
-            `50:LINT2001:Unreachable code`
+            `04:unreachable-code:Unreachable code`,
+            `10:unreachable-code:Unreachable code`,
+            `26:unreachable-code:Unreachable code`,
+            `41:unreachable-code:Unreachable code`,
+            `50:unreachable-code:Unreachable code`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -431,12 +431,12 @@ describe('trackCodeFlow', () => {
         } as any);
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `03:LINT1004:Variable 'A' was previously set with a different casing as 'a'`,
-            `04:LINT1004:Variable 'A' was previously set with a different casing as 'a'`,
-            `05:LINT1004:Variable 'A' was previously set with a different casing as 'a'`,
-            `06:LINT1004:Variable 'A' was previously set with a different casing as 'a'`,
-            `11:LINT1004:Variable 'A' was previously set with a different casing as 'a'`,
-            `15:LINT1004:Variable 'a' was previously set with a different casing as 'A'`
+            `03:case-mismatch:Variable 'A' was previously set with a different casing as 'a'`,
+            `04:case-mismatch:Variable 'A' was previously set with a different casing as 'a'`,
+            `05:case-mismatch:Variable 'A' was previously set with a different casing as 'a'`,
+            `06:case-mismatch:Variable 'A' was previously set with a different casing as 'a'`,
+            `11:case-mismatch:Variable 'A' was previously set with a different casing as 'a'`,
+            `15:case-mismatch:Variable 'a' was previously set with a different casing as 'A'`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -453,24 +453,24 @@ describe('trackCodeFlow', () => {
         } as any);
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `04:LINT2002:Sub as void should not return a value`,
             `04:return-type-mismatch:Type 'integer' is not compatible with declared return type 'void' '`,
+            `04:return-value-found:Sub as void should not return a value`,
             `04:unexpected-return-value:Void sub may not return a value`,
-            `11:LINT2002:Function as void should not return a value`,
             `11:return-type-mismatch:Type 'string' is not compatible with declared return type 'void' '`,
+            `11:return-value-found:Function as void should not return a value`,
             `11:unexpected-return-value:Void function may not return a value`,
-            `151:LINT2004:Not all code paths return a value`,
-            `15:LINT2006:Sub should consistently return a value`,
+            `151:unsafe-return-value:Not all code paths return a value`,
+            `15:missing-return-value:Sub should consistently return a value`,
             `15:return-type-mismatch:Type 'void' is not compatible with declared return type 'string' '`,
-            `18:LINT2004:Not all code paths return a value`,
             `18:return-type-coercion-mismatch:Function has no return statement and will return 'invalid': 'string' cannot be coerced into 'invalid'`,
-            `22:LINT2006:Function should consistently return a value`,
-            `25:LINT2004:Not all code paths return a value`,
-            `32:LINT2004:Not all code paths return a value`,
-            `39:LINT2004:Not all code paths return a value`,
-            `45:LINT2004:Not all code paths return a value`,
+            `18:unsafe-return-value:Not all code paths return a value`,
+            `22:missing-return-value:Function should consistently return a value`,
+            `25:unsafe-return-value:Not all code paths return a value`,
+            `32:unsafe-return-value:Not all code paths return a value`,
+            `39:unsafe-return-value:Not all code paths return a value`,
             `45:return-type-coercion-mismatch:Function has no return statement and will return 'invalid': 'string' cannot be coerced into 'invalid'`,
-            `49:LINT2004:Not all code paths return a value`
+            `45:unsafe-return-value:Not all code paths return a value`,
+            `49:unsafe-return-value:Not all code paths return a value`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -485,10 +485,10 @@ describe('trackCodeFlow', () => {
         });
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `02:LINT1005:Variable 'a' is set but value is never used`,
-            `08:LINT1005:Variable 'a' is set but value is never used`,
-            `12:LINT1005:Variable 'a' is set but value is never used`,
-            `21:LINT1005:Variable 'd' is set but value is never used`
+            `02:unused-variable:Variable 'a' is set but value is never used`,
+            `08:unused-variable:Variable 'a' is set but value is never used`,
+            `12:unused-variable:Variable 'a' is set but value is never used`,
+            `21:unused-variable:Variable 'd' is set but value is never used`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -503,8 +503,8 @@ describe('trackCodeFlow', () => {
         });
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `01:LINT1006:Parameter 'unusedParam' is set but value is never used`,
-            `06:LINT1006:Parameter 'hey' is set but value is never used`
+            `01:unused-parameter:Parameter 'unusedParam' is set but value is never used`,
+            `06:unused-parameter:Parameter 'hey' is set but value is never used`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -521,7 +521,7 @@ describe('trackCodeFlow', () => {
         } as any);
         const actual = fmtDiagnostics(diagnostics);
         const expected = [
-            `14:LINT1005:Variable 'a' is set but value is never used`
+            `14:unused-variable:Variable 'a' is set but value is never used`
         ];
         expect(actual).deep.equal(expected);
     });
@@ -550,7 +550,7 @@ describe('trackCodeFlow', () => {
             });
             const actual = fmtDiagnostics(diagnostics);
             const expected = [
-                `11:LINT1005:Variable 'A' is set but value is never used`
+                `11:unused-variable:Variable 'A' is set but value is never used`
             ];
             expect(actual).deep.equal(expected);
 

--- a/src/plugins/trackCodeFlow/returnTracking.ts
+++ b/src/plugins/trackCodeFlow/returnTracking.ts
@@ -12,6 +12,16 @@ interface ThrowInfo {
 }
 
 enum ReturnLintError {
+    UnreachableCode = 'unreachable-code',
+    ReturnValueUnexpected = 'return-value-found',
+    ReturnValueExpected = 'missing-return-value',
+    UnsafeReturnValue = 'unsafe-return-value',
+    ReturnValueRequired = 'return-value-required',
+    ReturnValueMissing = 'missing-return-value',
+    LastReturnValueMissing = 'missing-last-return-value'
+}
+
+enum ReturnLintLegacyError {
     UnreachableCode = 'LINT2001',
     ReturnValueUnexpected = 'LINT2002',
     ReturnValueExpected = 'LINT2003',
@@ -38,6 +48,7 @@ export function createReturnLinter(
             diagnostics.push({
                 severity: severity.unreachableCode,
                 code: ReturnLintError.UnreachableCode,
+                legacyCode: ReturnLintLegacyError.UnreachableCode,
                 message: 'Unreachable code',
                 location: curr.stat.location,
                 tags: [DiagnosticTag.Unnecessary]
@@ -108,6 +119,7 @@ export function createReturnLinter(
                     diagnostics.push({
                         severity: consistentReturn,
                         code: ReturnLintError.ReturnValueUnexpected,
+                        legacyCode: ReturnLintLegacyError.ReturnValueUnexpected,
                         message: `${kind} as void should not return a value`,
                         location: r.stat?.location ?? funLocation
                     });
@@ -129,6 +141,7 @@ export function createReturnLinter(
             diagnostics.push({
                 severity: consistentReturn,
                 code: ReturnLintError.UnsafeReturnValue,
+                legacyCode: ReturnLintLegacyError.ReturnValueRequired,
                 message: 'Not all code paths return a value',
                 location: funLocation
             });
@@ -142,6 +155,7 @@ export function createReturnLinter(
                     diagnostics.push({
                         severity: consistentReturn,
                         code: ReturnLintError.ReturnValueMissing,
+                        legacyCode: ReturnLintLegacyError.ReturnValueMissing,
                         message: `${kind} should consistently return a value`,
                         location: r.stat.location || funLocation
                     });

--- a/src/plugins/trackCodeFlow/varTracking.ts
+++ b/src/plugins/trackCodeFlow/varTracking.ts
@@ -4,6 +4,15 @@ import { PluginContext } from '../../util';
 import { Location } from 'vscode-languageserver-types';
 
 export enum VarLintError {
+    UninitializedVar = 'uninitialized-variable',
+    UnsafeIteratorVar = 'unsafe-iterator-variable',
+    UnsafeInitialization = 'unsafe-initialization',
+    CaseMismatch = 'case-mismatch',
+    UnusedVariable = 'unused-variable',
+    UnusedParameter = 'unused-parameter'
+}
+
+export enum VarLintLegacyError {
     UninitializedVar = 'LINT1001',
     UnsafeIteratorVar = 'LINT1002',
     UnsafeInitialization = 'LINT1003',
@@ -24,6 +33,7 @@ export const VarTrackingMessages = {
         severity: DiagnosticSeverity.Warning,
         source: 'bslint',
         code: VarLintError.CaseMismatch,
+        legacyCode: VarLintLegacyError.CaseMismatch,
         message: `Variable '${name.text}' was previously set with a different casing as '${curr.name}'`,
         data: {
             name: curr.name,
@@ -34,24 +44,28 @@ export const VarTrackingMessages = {
         severity: DiagnosticSeverity.Error,
         source: 'bslint',
         code: VarLintError.UnsafeIteratorVar,
+        legacyCode: VarLintLegacyError.UnsafeIteratorVar,
         message: `Using iterator variable '${name}' outside loop`
     }),
     unusedVariable: (name: string) => ({
         severity: DiagnosticSeverity.Warning,
         source: 'bslint',
         code: VarLintError.UnusedVariable,
+        legacyCode: VarLintLegacyError.UnusedVariable,
         message: `Variable '${name}' is set but value is never used`
     }),
     unsafeInitialization: (name: string) => ({
         severity: DiagnosticSeverity.Error,
         source: 'bslint',
         code: VarLintError.UnsafeInitialization,
+        legacyCode: VarLintLegacyError.UnsafeInitialization,
         message: `Not all the code paths assign '${name}'`
     }),
     uninitializedVariable: (name: string, scopeName: string) => ({
         severity: DiagnosticSeverity.Error,
         source: 'bslint',
         code: VarLintError.UninitializedVar,
+        legacyCode: VarLintLegacyError.UninitializedVar,
         message: `Using uninitialised variable '${name}' when this file is included in scope '${scopeName}'`
     })
 };
@@ -402,18 +416,7 @@ export function createVarLinter(
                 diagnostics.push({
                     severity: severity.unusedParameter,
                     code: VarLintError.UnusedParameter,
-                    message: `Parameter '${arg.name}' is set but value is never used`,
-                    location: arg.location
-                });
-            }
-        });
-
-        args.forEach(arg => {
-            // treat a leading underscore as an intentionally unused parameter
-            if (!arg.isUsed && !arg.name.startsWith('_')) {
-                diagnostics.push({
-                    severity: severity.unusedParameter,
-                    code: VarLintError.UnusedParameter,
+                    legacyCode: VarLintLegacyError.UnusedParameter,
                     message: `Parameter '${arg.name}' is set but value is never used`,
                     location: arg.location
                 });

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -122,7 +122,7 @@ export function fmtDiagnostics(diagnostics: BsDiagnostic[]) {
     return diagnostics
         .filter((d) => d.severity && d.severity < 4)
         .sort((a, b) => a.location.range.start.line - b.location.range.start.line)
-        .map((d) => `${pad(d.location.range.start.line + 1)}:${d.code}:${d.message}`)
+        .map((d) => `${pad(d.location.range.start.line + 1)}:${d.code || d.legacyCode}:${d.message}`)
         .map(d => d.trim())
         .sort();
 }


### PR DESCRIPTION
- Previous codes are included as `legacyCode` so they can still be filtered

| Diagnostic | New Code | Legacy Code |
|---|---|---|
| VarTracking.UninitializedVar | uninitialized-variable | LINT1001 |
| VarTracking.UnsafeIteratorVar | unsafe-iterator-variable | LINT1002 |
| VarTracking.UnsafeInitialization | unsafe-initialization | LINT1003 |
| VarTracking.CaseMismatch | case-mismatch | LINT1004 |
| VarTracking.UnusedVariable | unused-variable | LINT1005 |
| VarTracking.UnusedParameter | unused-parameter | LINT1006 |
| ReturnTracking.UnreachableCode | unreachable-code | LINT2001 |
| ReturnTracking.ReturnValueUnexpected | return-value-found | LINT2002 |
| ReturnTracking.ReturnValueExpected | missing-return-value | LINT2003 |
| ReturnTracking.UnsafeReturnValue | unsafe-return-value | LINT2005 |
| ReturnTracking.ReturnValueRequired | return-value-required | LINT2005 |
| ReturnTracking.ReturnValueMissing | missing-return-value | LINT2006 |
| ReturnTracking.LastReturnValueMissing | missing-last-return-value | LINT2007 |
| CodeStyle.InlineIfFound | inline-if-found | LINT3001 |
| CodeStyle.InlineIfThenMissing | missing-inline-if-then | LINT3002 |
| CodeStyle.InlineIfThenFound | inline-if-then-found | LINT3003 |
| CodeStyle.BlockIfThenMissing | missing-block-if-then | LINT3004 |
| CodeStyle.BlockIfThenFound | block-if-then-found | LINT3005 |
| CodeStyle.ConditionGroupMissing | missing-condition-group | LINT3006 |
| CodeStyle.ConditionGroupFound | condition-group-found | LINT3007 |
| CodeStyle.SubKeywordExpected | missing-sub-keyword | LINT3008 |
| CodeStyle.FunctionKeywordExpected | missing-function-keyword | LINT3009 |
| CodeStyle.ReturnTypeAnnotation | missing-return-type | LINT3010 |
| CodeStyle.TypeAnnotation | missing-type | LINT3011 |
| CodeStyle.NoPrint | no-print | LINT3012 |
| CodeStyle.AACommaFound | aa-comma-found | LINT3013 |
| CodeStyle.AACommaMissing | missing-aa-comma | LINT3014 |
| CodeStyle.NoTodo | no-todo | LINT3015 |
| CodeStyle.NoStop | no-stop | LINT3016 |
| CodeStyle.EolLastMissing | missing-eol-last | LINT3017 |
| CodeStyle.EolLastFound | eol-last-found | LINT3018 |
| CodeStyle.ColorFormat | color-format | LINT3019 |
| CodeStyle.ColorCase | color-case | LINT3020 |
| CodeStyle.ColorAlpha | color-alpha | LINT3021 |
| CodeStyle.ColorAlphaDefaults | color-alpha-defaults | LINT3022 |
| CodeStyle.ColorCertCompliant | color-cert-compliant | LINT3023 |
| CodeStyle.NoAssocarrayFieldType | no-assocarray-field-type | LINT3024 |
| CodeStyle.NoArrayFieldType | no-array-field-type | LINT3025 |
| CodeStyle.NoRegexDuplicates | no-regex-duplicates | LINT3026 |
| CodeStyle.ForTerminatorEndForExpected | missing-end-for | LINT3027 |
| CodeStyle.ForTerminatorNextExpected | missing-next | LINT3028 |
| CodeStyle.NameShadowing | name-shadowing | LINT3127 |
| CodeStyle.TypeReassignment | type-reassignment | N/A |
| CheckUsage.UnusedComponent | unused-component | LINT4001 |
| CheckUsage.UnusedScript | unused-script | LINT4002 |


