### PR TITLE
Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2824,15 +2824,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -8107,15 +8108,15 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:nocover": "mocha",
     "test:watch": "npm run test -- --watch --watch-files \"src/**/*.ts,test/**/*.brs\"",
     "watch": "tsc --watch",
-    "audit": "npm audit || audit-ci --config ./audit-ci.jsonc",
+    "audit": "npm audit --audit-level=high || audit-ci --config ./audit-ci.jsonc",
     "package": "npm run build && npm pack"
   },
   "files": [


### PR DESCRIPTION
Clears the outstanding high-severity audit advisory and aligns the audit gate with the other RokuCommunity repos.

- Bump `form-data` `2.5.5` → `2.5.6` (lockfile), clearing the CRLF advisory GHSA-hmw2-7cc7-3qxx. It comes in transitively via `brighterscript` → `roku-deploy` → `@types/request` (which allows `^2.5.5`), so no manifest change is needed. Same bump the sibling repos already merged.
- Raise the `npm audit` step to `--audit-level=high` so the audit script only gates on high and above.

No high/critical advisories remain; `build`, `lint`, and tests pass.