### PR TITLE
chore: Security enhancements

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -3,13 +3,5 @@
     // why each allowlisted entry is safe to defer.
     "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
     "high": true,
-    "allowlist": [
-        {
-            "GHSA-w5hq-g745-h8pq": {
-                // Added: 2026-05-22
-                "active": true,
-                "notes": "`uuid` <11.1.1 (via `postman-request` and dev-only `nyc>istanbul-lib-processinfo`): vulnerable code path is `v3()`/`v5()`/`v6()` when a caller-provided buffer is passed. All consumers in this dep graph call only `v4()` (no buffer arg), so the vulnerable path is unreachable."
-            }
-        }
-    ]
+    "allowlist": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,6 +1235,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1670,6 +1671,12 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
@@ -2754,6 +2761,29 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/istanbul-lib-processinfo/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/istanbul-lib-processinfo/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -3239,6 +3269,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/minipass": {
@@ -5225,7 +5265,7 @@
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.3.2",
+        "js-yaml": "^4",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -5273,7 +5313,7 @@
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
         "get-package-type": "^0.1.0",
-        "js-yaml": "^4.3.2",
+        "js-yaml": "^4",
         "resolve-from": "^5.0.0"
       }
     },
@@ -5839,6 +5879,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0"
       }
@@ -6157,6 +6198,11 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -6323,7 +6369,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^4.3.2",
+        "js-yaml": "^4",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -6940,7 +6986,7 @@
       "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.29.7",
+        "@babel/core": "^7",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
@@ -6959,6 +7005,21 @@
         "rimraf": "^6.1.3"
       },
       "dependencies": {
+        "balanced-match": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+          "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^4.0.2"
+          }
+        },
         "glob": {
           "version": "13.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -6976,7 +7037,7 @@
           "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.1.4"
+            "brace-expansion": "^5.0.8"
           }
         },
         "rimraf": {
@@ -7313,7 +7374,18 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "requires": {
-        "brace-expansion": "^2.1.4"
+        "brace-expansion": "^1.1.18"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.18",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+          "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        }
       }
     },
     "minipass": {
@@ -7337,11 +7409,11 @@
         "find-up": "^5.0.0",
         "glob": "^8.1.0",
         "he": "^1.2.0",
-        "js-yaml": "^4.3.2",
+        "js-yaml": "^4",
         "log-symbols": "^4.1.0",
         "minimatch": "^5.1.6",
         "ms": "^2.1.3",
-        "serialize-javascript": "^7.0.5",
+        "serialize-javascript": "^7",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
@@ -7441,7 +7513,7 @@
           "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.1.4"
+            "brace-expansion": "^2"
           }
         },
         "p-limit": {
@@ -8162,7 +8234,7 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.1.7",
+            "fast-uri": "^3",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }

--- a/package.json
+++ b/package.json
@@ -63,14 +63,13 @@
     "brighterscript": ">= 0.59.0 < 1"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.5",
-    "brace-expansion": "^2.1.4",
-    "js-yaml": "^4.3.2",
-    "fast-uri": "^3.1.7",
+    "serialize-javascript": "^7",
+    "brace-expansion@^1": "^1.1.18",
+    "brace-expansion@^2": "^2",
+    "js-yaml": "^4",
+    "fast-uri": "^3",
     "istanbul-lib-processinfo": "^3.0.1",
-    "ip-address": "^10.4.0",
-    "@babel/core": "^7.29.7",
-    "qs": "^6.15.3"
+    "@babel/core": "^7"
   },
   "mocha": {
     "config": ".mocharc.cjs"


### PR DESCRIPTION
Clears the uuid allowlist entry and fixes a `brace-expansion` override that was quietly leaving consumers exposed.

`npm run audit`: **0 vulnerabilities with an empty allowlist.**

## Ships to consumers
`brace-expansion` on the prod path now resolves **1.1.18** instead of 2.1.4 — see below. No other prod resolution changes.

## Lockfile only (dev deps)
| Override | Change |
|---|---|
| `qs`, `ip-address` | **removed** — neither package is in this dep graph |
| `serialize-javascript`, `js-yaml`, `fast-uri`, `@babel/core` | patch floor → major range |

## Notes for the reviewer
- **The prod fix is the part worth a look.** The blanket `brace-expansion: ^2.1.4` override forced `minimatch@3` — a *direct prod dependency* — past its declared `^1.1.7`. Since consumers don't inherit `overrides`, anyone installing `@rokucommunity/bslint` still got minimatch@3 with a vulnerable `brace-expansion@1.x`, while our CI tested a combination they never receive. Scoping by major line puts prod on a patched 1.x inside minimatch's declared range, so consumers now resolve safely on their own.
- The uuid allowlist entry was dead: `npm ls uuid` returns empty. `istanbul-lib-processinfo: ^3.0.1` was already in place here and had removed it.

## Verification
`npm run preversion` (build + lint + test) passes. Confirmed `npm ls brace-expansion --omit=dev` resolves 1.1.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)